### PR TITLE
Feat/analysis : URL 기반 뉴스 기사 분석  기능 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springAiVersion', "1.0.0")
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
@@ -43,6 +47,25 @@ dependencies {
     //OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    //Jsoup
+    implementation 'org.jsoup:jsoup:1.16.1'
+    implementation 'net.dankito.readability4j:readability4j:1.0.8'
+
+    //SpringAI
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+
+    //Mapper
+    // MapStruct 라이브러리
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    // MapStruct 코드 생성기
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
@@ -96,7 +96,8 @@ public class SecurityConfig {
                                 "/api/nocap/auth/signup",
                                 "/api/nocap/auth/login",
                                 "/oauth2/authorization/**",
-                                "/api/v1/oauth2/**"
+                                "/api/v1/oauth2/**",
+                                "/api/analysis" // 테스트용 전체 허용
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/example/nocap/domain/analysis/config/NaverApiConfig.java
+++ b/src/main/java/com/example/nocap/domain/analysis/config/NaverApiConfig.java
@@ -1,0 +1,17 @@
+package com.example.nocap.domain.analysis.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class NaverApiConfig {
+
+    @Value("${naver.client.id}")
+    private String clientId;
+
+    @Value("${naver.client.secret}")
+    private String clientSecret;
+
+}

--- a/src/main/java/com/example/nocap/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/example/nocap/domain/analysis/controller/AnalysisController.java
@@ -1,0 +1,33 @@
+package com.example.nocap.domain.analysis.controller;
+
+import com.example.nocap.domain.analysis.dto.SbertRequestDto;
+import com.example.nocap.domain.analysis.service.AnalysisProcessService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/analysis")
+public class AnalysisController {
+
+    private final AnalysisProcessService analysisProcessService;
+
+    public AnalysisController(AnalysisProcessService analysisProcessService) {
+        this.analysisProcessService = analysisProcessService;
+    }
+
+    @GetMapping
+    public ResponseEntity<SbertRequestDto> searchNews(@RequestParam("url") String url) {
+
+        SbertRequestDto sbertRequestDto = analysisProcessService.analyzeUrlAndPrepareRequest(url);
+
+        // SbertRequestDto를 lambda 호출로 보내기
+        // 유사도, 비교요약을 담은 데이터 반환받기
+        // 분석, 메인뉴스, 뉴스를 각 레포에 저장
+
+        return ResponseEntity.ok(sbertRequestDto);
+    }
+}

--- a/src/main/java/com/example/nocap/domain/analysis/dto/CrawledResponseDto.java
+++ b/src/main/java/com/example/nocap/domain/analysis/dto/CrawledResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.nocap.domain.analysis.dto;
+
+import com.example.nocap.domain.news.dto.NewsDto;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CrawledResponseDto {
+
+    private List<NewsDto> newsDtoList;
+
+}

--- a/src/main/java/com/example/nocap/domain/analysis/dto/NewsSearchRequestDto.java
+++ b/src/main/java/com/example/nocap/domain/analysis/dto/NewsSearchRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.nocap.domain.analysis.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class NewsSearchRequestDto {
+
+    // Naver News API를 요청할 키워드와 결과에서 제외할 제목(원본 제목)
+    private String rawKeyword;
+    private String excludeTitle;
+
+}

--- a/src/main/java/com/example/nocap/domain/analysis/dto/NewsSearchResponseDto.java
+++ b/src/main/java/com/example/nocap/domain/analysis/dto/NewsSearchResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.nocap.domain.analysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NewsSearchResponseDto {
+
+    private String lastBuildDate;
+    private int total;
+    private int start;
+    private int display;
+    private List<Item> items;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Item {
+        private String title;
+        private String originallink;
+        private String link;
+        private String description;
+        private String pubDate;
+    }
+
+}

--- a/src/main/java/com/example/nocap/domain/analysis/dto/SbertRequestDto.java
+++ b/src/main/java/com/example/nocap/domain/analysis/dto/SbertRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.nocap.domain.analysis.dto;
+
+import com.example.nocap.domain.mainnews.dto.MainNewsDto;
+import com.example.nocap.domain.news.dto.NewsDto;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SbertRequestDto {
+
+    private String plan;
+    private String category;
+    private MainNewsDto mainNewsDto;
+    private List<NewsDto> newsDtoList;
+
+}

--- a/src/main/java/com/example/nocap/domain/analysis/dto/TitleCategoryDto.java
+++ b/src/main/java/com/example/nocap/domain/analysis/dto/TitleCategoryDto.java
@@ -1,0 +1,11 @@
+package com.example.nocap.domain.analysis.dto;
+
+import lombok.Data;
+
+@Data
+public class TitleCategoryDto {
+
+    private String title;
+    private String category;
+
+}

--- a/src/main/java/com/example/nocap/domain/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/com/example/nocap/domain/analysis/repository/AnalysisRepository.java
@@ -1,0 +1,5 @@
+package com.example.nocap.domain.analysis.repository;
+
+public interface AnalysisRepository{
+
+}

--- a/src/main/java/com/example/nocap/domain/analysis/service/AnalysisProcessService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/AnalysisProcessService.java
@@ -1,0 +1,53 @@
+package com.example.nocap.domain.analysis.service;
+
+import com.example.nocap.domain.analysis.dto.*;
+import com.example.nocap.domain.mainnews.entity.MainNews;
+import com.example.nocap.domain.mainnews.mapper.MainNewsMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AnalysisProcessService {
+
+    private final ArticleExtractionService articleExtractionService;
+    private final OpenAIService openAIService;
+    private final SearchService searchService;
+    private final CrawlingService crawlingService;
+    private final MainNewsMapper mainNewsMapper;
+
+    public AnalysisProcessService(ArticleExtractionService articleExtractionService,
+        OpenAIService openAIService, SearchService searchService,
+        CrawlingService crawlingService, MainNewsMapper mainNewsMapper) {
+        this.articleExtractionService = articleExtractionService;
+        this.openAIService = openAIService;
+        this.searchService = searchService;
+        this.crawlingService = crawlingService;
+        this.mainNewsMapper = mainNewsMapper;
+    }
+    public SbertRequestDto analyzeUrlAndPrepareRequest(String url) {
+        // 1. URL에서 메인 기사 추출
+        MainNews mainNews = articleExtractionService.extract(url);
+        System.out.println("추출된 기사 제목 : " + mainNews.getTitle());
+
+        // 2. OpenAI로 새 제목/카테고리 생성
+        TitleCategoryDto titleCategoryDto = openAIService.generate(mainNews.getContent());
+        System.out.println("챗지피티가 새로 구성한 제목 : " + titleCategoryDto.getTitle());
+
+        // 3. 새 제목으로 관련 뉴스 검색
+        NewsSearchRequestDto newsSearchRequestDto = NewsSearchRequestDto.builder()
+            .rawKeyword(titleCategoryDto.getTitle())
+            .excludeTitle(mainNews.getTitle())
+            .build();
+        NewsSearchResponseDto searchResult = searchService.searchNewsDto(newsSearchRequestDto);
+        System.out.println("네이버 뉴스 API 호출 시간 : " + searchResult.getLastBuildDate());
+
+        // 4. 검색된 뉴스들 크롤링
+        CrawledResponseDto crawledResponseDto = crawlingService.crawlNews(searchResult);
+
+        // 5. 최종 DTO 빌드
+        return SbertRequestDto.builder()
+            .category(titleCategoryDto.getCategory())
+            .mainNewsDto(mainNewsMapper.toMainNewsDto(mainNews))
+            .newsDtoList(crawledResponseDto.getNewsDtoList())
+            .build();
+    }
+}

--- a/src/main/java/com/example/nocap/domain/analysis/service/ArticleExtractionService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/ArticleExtractionService.java
@@ -1,0 +1,72 @@
+package com.example.nocap.domain.analysis.service;
+
+import com.example.nocap.domain.mainnews.entity.MainNews;
+import com.example.nocap.exception.CustomException;
+import com.example.nocap.exception.ErrorCode;
+import java.io.IOException;
+import net.dankito.readability4j.Article;
+import net.dankito.readability4j.Readability4J;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ArticleExtractionService {
+
+    public MainNews extract(String url) {
+        try {
+            Document doc = Jsoup.connect(url)
+                .userAgent("Mozilla/5.0")
+                .timeout(5_000)
+                .get();
+
+            // 기사 여부 판별 로직
+            if (!isArticleByConfidenceScore(doc)) {
+                // ✨ 변경점 1: 기사가 아닐 때 BusinessException 발생
+                throw new CustomException(ErrorCode.NOT_A_NEWS_ARTICLE);
+            }
+
+            Element ogImageElement = doc.selectFirst("meta[property=og:image]");
+            String ogImage = (ogImageElement != null) ? ogImageElement.attr("content") : "";
+
+            Article article = new Readability4J(url, doc.html()).parse();
+
+            String htmlContent = article.getContent();
+            String plainContent = Jsoup.parse(htmlContent).text();
+
+            return MainNews.builder()
+                .url(url)
+                .title(article.getTitle())
+                .content(plainContent)
+                .image(ogImage)
+                .build();
+
+        } catch (IOException e) {
+            // ✨ 변경점 2: Jsoup 연결 실패 시 BusinessException 발생
+            throw new CustomException(ErrorCode.EXTERNAL_API_ERROR);
+        }
+    }
+
+    private boolean isArticleByConfidenceScore(Document doc) {
+        // ... (이전과 동일한 점수제 판별 로직) ...
+        int confidenceScore = 0;
+        final int THRESHOLD = 4;
+
+        Element ogTypeElement = doc.selectFirst("meta[property=og:type]");
+        if (ogTypeElement != null && "article".equalsIgnoreCase(ogTypeElement.attr("content"))) {
+            confidenceScore += 5;
+        }
+        if (doc.selectFirst("article") != null) {
+            confidenceScore += 3;
+        }
+        if (doc.selectFirst("div[class*='article'], div[class*='content'], div[id*='article'], div[id*='content']") != null) {
+            confidenceScore += 2;
+        }
+        if (doc.selectFirst("h1") != null) {
+            confidenceScore += 1;
+        }
+
+        return confidenceScore >= THRESHOLD;
+    }
+}

--- a/src/main/java/com/example/nocap/domain/analysis/service/CrawlingService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/CrawlingService.java
@@ -1,0 +1,51 @@
+package com.example.nocap.domain.analysis.service;
+
+import com.example.nocap.domain.analysis.dto.CrawledResponseDto;
+import com.example.nocap.domain.analysis.dto.NewsSearchResponseDto;
+import com.example.nocap.domain.news.dto.NewsDto;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CrawlingService {
+
+    /**
+     * NewsResponse 에 담긴 각 아이템의 originallink 로 크롤링을 수행하여
+     * CrawledNewsResponse 로 반환
+     */
+    public CrawledResponseDto crawlNews(NewsSearchResponseDto newsSearchResponseDto) {
+        List<NewsDto> crawledNews = new ArrayList<>();
+
+        for (NewsSearchResponseDto.Item item : newsSearchResponseDto.getItems()) {
+            String url = item.getOriginallink();
+            String fullText;
+            try {
+                Document doc = Jsoup.connect(url)
+                    .userAgent("Mozilla/5.0")
+                    .timeout(5000)
+                    .get();
+                if (doc.selectFirst("article") != null) {
+                    fullText = doc.select("article").text();
+                } else {
+                    fullText = doc.body().text();
+                }
+            } catch (IOException e) {
+                fullText = "[크롤링 실패] " + e.getMessage();
+            }
+
+            crawledNews.add(new NewsDto(
+                url,
+                item.getTitle(),
+                fullText
+            ));
+        }
+
+        return CrawledResponseDto.builder()
+            .newsDtoList(crawledNews) // 빌더를 통해 값을 설정
+            .build();                 // build() 메소드로 객체 생성
+    }
+}

--- a/src/main/java/com/example/nocap/domain/analysis/service/OpenAIService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/OpenAIService.java
@@ -1,0 +1,52 @@
+package com.example.nocap.domain.analysis.service;
+
+import com.example.nocap.domain.analysis.dto.TitleCategoryDto;
+import java.util.List;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OpenAIService {
+
+    private final OpenAiChatModel openAiChatModel;
+
+    public OpenAIService(OpenAiChatModel openAiChatModel) {
+        this.openAiChatModel = openAiChatModel;
+    }
+
+    public TitleCategoryDto generate(String text) {
+
+        ChatClient chatClient = ChatClient.create(openAiChatModel);
+
+        // 이스케이프된 큰따옴표를 실제 큰따옴표로
+        text = text.replace("\\\"", "\"");
+
+        // 메시지
+        SystemMessage systemMessage = new SystemMessage(
+            "다음 뉴스 기사 본문을 바탕으로, 핵심 명사만 추출해 공백으로 구분된 검색어 형태로 만들어주세요. " +
+                "조사·접속사·구두점 제거, 중복 없이 5~8개 주요 키워드 포함, 30자 이내 작성 예: '네이버 21대 대선 정치 댓글 감소'" +
+                "입력된 기사의 내용을 통해 다음 category 중 하나로 분류를 해주세요: '정치', '경제', '사회', '생활문화', 'IT과학', '세계', '기타'"
+        );
+        UserMessage userMessage = new UserMessage(text);
+        AssistantMessage assistantMessage = new AssistantMessage("");
+
+        // 옵션
+        OpenAiChatOptions options = OpenAiChatOptions.builder()
+            .model("gpt-4.1-mini")
+            .temperature(0.1)
+            .build();
+
+        // 프롬프트
+        Prompt prompt = new Prompt(List.of(systemMessage, userMessage, assistantMessage), options);
+
+        // 요청 및 응답
+        return chatClient.prompt(prompt).call().entity(TitleCategoryDto.class);
+    }
+
+}

--- a/src/main/java/com/example/nocap/domain/analysis/service/SearchService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/SearchService.java
@@ -1,0 +1,146 @@
+package com.example.nocap.domain.analysis.service;
+
+import com.example.nocap.domain.analysis.config.NaverApiConfig;
+import com.example.nocap.domain.analysis.dto.NewsSearchRequestDto;
+import com.example.nocap.domain.analysis.dto.NewsSearchResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jsoup.Jsoup;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SearchService {
+
+    private final NaverApiConfig config;
+    private final ObjectMapper mapper;
+
+    public SearchService(NaverApiConfig config, ObjectMapper mapper) {
+        this.config = config;
+        this.mapper = mapper;
+    }
+
+    public NewsSearchResponseDto searchNewsDto(NewsSearchRequestDto newsSearchRequestDto) {
+        // 1. 11개 가져오기
+        String json = requestRawJson(newsSearchRequestDto.getRawKeyword());
+        // 2. JSON → DTO
+        NewsSearchResponseDto newsSearchResponseDto = jsonToDto(json);
+        /// 3. 제목 HTML 태그 제거
+        sanitizeItems(newsSearchResponseDto);
+        // 4. excludeTitle 검사 및 최종 DTO 반환
+        return excludeOrTrim(newsSearchResponseDto, newsSearchRequestDto.getExcludeTitle());
+    }
+    private void sanitizeItems(NewsSearchResponseDto newsSearchResponseDto) {
+        if (newsSearchResponseDto.getItems() == null) return;
+
+        for (NewsSearchResponseDto.Item item : newsSearchResponseDto.getItems()) {
+            // 제목에서 태그 제거
+            if (item.getTitle() != null) {
+                String plainTitle = Jsoup.parse(item.getTitle()).text();
+                item.setTitle(plainTitle);
+            }
+            // (선택) description 에서도 태그 제거가 필요하면 아래 추가
+            if (item.getDescription() != null) {
+                String plainDesc = Jsoup.parse(item.getDescription()).text();
+                item.setDescription(plainDesc);
+            }
+        }
+    }
+
+    private NewsSearchResponseDto jsonToDto(String json) {
+        try {
+            return mapper.readValue(json, NewsSearchResponseDto.class);
+        } catch (IOException e) {
+            throw new RuntimeException("JSON → DTO 변환 실패", e);
+        }
+    }
+
+    private String requestRawJson(String rawKeyword) {
+        String query;
+        try {
+            query = URLEncoder.encode(rawKeyword, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("검색어 인코딩 실패", e);
+        }
+
+        String apiURL = "https://openapi.naver.com/v1/search/news.json"
+            + "?query=" + query
+            + "&display=" + 11
+            + "&start=1"
+            + "&sort=sim";
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Naver-Client-Id",     config.getClientId());
+        headers.put("X-Naver-Client-Secret", config.getClientSecret());
+
+        HttpURLConnection con = connect(apiURL);
+        try {
+            con.setRequestMethod("GET");
+            headers.forEach(con::setRequestProperty);
+
+            int code = con.getResponseCode();
+            InputStream is = (code == HttpURLConnection.HTTP_OK)
+                ? con.getInputStream()
+                : con.getErrorStream();
+            return readBody(is);
+        } catch (IOException e) {
+            throw new RuntimeException("API 요청 실패", e);
+        } finally {
+            con.disconnect();
+        }
+    }
+
+    private HttpURLConnection connect(String apiUrl) {
+        try {
+            URL url = new URL(apiUrl);
+            return (HttpURLConnection) url.openConnection();
+        } catch (IOException e) {
+            throw new RuntimeException("연결 실패: " + apiUrl, e);
+        }
+    }
+
+    private String readBody(InputStream body) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(body))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = br.readLine()) != null) {
+                sb.append(line);
+            }
+            return sb.toString();
+        } catch (IOException e) {
+            throw new RuntimeException("응답 읽기 실패", e);
+        }
+    }
+
+    private NewsSearchResponseDto excludeOrTrim(NewsSearchResponseDto resp, String excludeTitle) {
+        // 1. 원본 리스트 복사
+        List<NewsSearchResponseDto.Item> items = new ArrayList<>(resp.getItems());
+
+        // 2. HTML 태그 제거한 텍스트로 비교해서 제거
+        boolean removed = items.removeIf(item -> {
+            // <b>태그 등 HTML 제거
+            String plainTitle = Jsoup.parse(item.getTitle()).text();
+            return plainTitle.equals(excludeTitle);
+        });
+
+        // 3. 중복 제거된 게 없고, 11개 이상일 때 마지막 하나만 제거
+        if (!removed && items.size() > 10) {
+            items.remove(items.size() - 1);
+        }
+
+        // 4. DTO 업데이트
+        resp.setItems(items);
+        resp.setDisplay(items.size());
+        return resp;
+    }
+}

--- a/src/main/java/com/example/nocap/domain/mainnews/dto/MainNewsDto.java
+++ b/src/main/java/com/example/nocap/domain/mainnews/dto/MainNewsDto.java
@@ -1,0 +1,17 @@
+package com.example.nocap.domain.mainnews.dto;
+
+import jakarta.persistence.Column;
+import lombok.Data;
+
+@Data
+public class MainNewsDto {
+
+    private String url;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+
+}

--- a/src/main/java/com/example/nocap/domain/mainnews/mapper/MainNewsMapper.java
+++ b/src/main/java/com/example/nocap/domain/mainnews/mapper/MainNewsMapper.java
@@ -1,0 +1,15 @@
+package com.example.nocap.domain.mainnews.mapper;
+
+import com.example.nocap.domain.mainnews.dto.MainNewsDto;
+import com.example.nocap.domain.mainnews.entity.MainNews;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface MainNewsMapper {
+
+    MainNewsMapper INSTANCE = Mappers.getMapper(MainNewsMapper.class);
+
+    MainNewsDto toMainNewsDto(MainNews mainNews);
+
+}

--- a/src/main/java/com/example/nocap/domain/mainnews/repository/MainNewsRepository.java
+++ b/src/main/java/com/example/nocap/domain/mainnews/repository/MainNewsRepository.java
@@ -1,0 +1,10 @@
+package com.example.nocap.domain.mainnews.repository;
+
+import com.example.nocap.domain.mainnews.entity.MainNews;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MainNewsRepository extends JpaRepository<MainNews, Long> {
+
+}

--- a/src/main/java/com/example/nocap/domain/news/dto/NewsDto.java
+++ b/src/main/java/com/example/nocap/domain/news/dto/NewsDto.java
@@ -1,0 +1,17 @@
+package com.example.nocap.domain.news.dto;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class NewsDto {
+
+    private String url;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+}

--- a/src/main/java/com/example/nocap/domain/news/repository/NewsRepository.java
+++ b/src/main/java/com/example/nocap/domain/news/repository/NewsRepository.java
@@ -1,0 +1,10 @@
+package com.example.nocap.domain.news.repository;
+
+import com.example.nocap.domain.news.entity.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NewsRepository extends JpaRepository<News, Long> {
+
+}

--- a/src/main/java/com/example/nocap/exception/CustomException.java
+++ b/src/main/java/com/example/nocap/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.example.nocap.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super();
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/example/nocap/exception/ErrorCode.java
+++ b/src/main/java/com/example/nocap/exception/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.example.nocap.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 400 Bad Request: 잘못된 요청
+    NOT_A_NEWS_ARTICLE(HttpStatus.BAD_REQUEST, "제공된 URL은 뉴스 기사가 아닙니다."),
+
+    // 401 Unauthorized: 인증되지 않은 사용자
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요한 요청입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+
+    // 404 Not Found: 리소스를 찾을 수 없음
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기사를 찾을 수 없습니다."),
+
+    // 409 Conflict: 충돌
+    DUPLICATE_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+
+    // 500 Internal Server Error: 서버 내부 오류
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에 알 수 없는 오류가 발생했습니다."),
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 호출 중 오류가 발생했습니다.");
+
+
+    private final HttpStatus status;       // HTTP 상태 코드
+    private final String message;        // 에러 메시지
+}

--- a/src/main/java/com/example/nocap/exception/ErrorResponse.java
+++ b/src/main/java/com/example/nocap/exception/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.example.nocap.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/example/nocap/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/nocap/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.example.nocap.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        ErrorResponse response = ErrorResponse.builder()
+            .status(errorCode.getStatus().value())
+            .message(errorCode.getMessage())
+            .build();
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+}


### PR DESCRIPTION
### 반영 브랜치
feat/analysis -> dev

### 변경 사항
SBERT 호출 이전까지의 로직을 구현
- 로직
  - url을 입력받으면 점수제를 통해 기사 여부를 판단
  - 기사가 아닌 경우 ErrorCode로 지정한 오류 메세지 반환
  - 메인 기사에서 chatGPT로 새 제목과 카테고리 추출
  - 새 제목으로 관련 뉴스를 네이버 뉴스 API로 호출 후 크롤링으로 각각의 전체 본문 가져오기
  - 메인 뉴스와 관련 뉴스를 플랜, 카테고리와 함께 SBERT로 전송
- 추가
  - ErrorCode를 Enum으로 관리
  - 메세지와 에러코드를 담은 CustomException 생성
  - Jsoup, SpringAI, Mapper를 위한 의존성 추가 및 테스트를 위한 SpringSecurity 수정

### 테스트 결과
<img width="2022" height="740" alt="image" src="https://github.com/user-attachments/assets/bd3853f6-c103-47f8-a66a-0d268f9b98ff" />
<img width="2014" height="1468" alt="image" src="https://github.com/user-attachments/assets/77caf2de-e80a-4e20-95d1-75aad409f3b0" />
