### PR TITLE
[Feat] Logout with memory blacklist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     // Fast API - WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // blacklist cache library
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 }
 
 dependencyManagement {

--- a/src/main/java/com/example/nocap/auth/config/JwtUtil.java
+++ b/src/main/java/com/example/nocap/auth/config/JwtUtil.java
@@ -45,6 +45,11 @@ public class JwtUtil {
                 .parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
+    public Date getExpiration(String token) {
+        return Jwts.parser().verifyWith(secretKey).build()
+                .parseSignedClaims(token).getPayload().getExpiration();
+    }
+
     public Long getId(String token) {
         return Jwts.parser().verifyWith(secretKey).build()
                 .parseSignedClaims(token).getPayload().get("id", Long.class);

--- a/src/main/java/com/example/nocap/auth/controller/AuthController.java
+++ b/src/main/java/com/example/nocap/auth/controller/AuthController.java
@@ -57,4 +57,9 @@ public class AuthController implements AuthSwagger{
     public ResponseEntity<?> formLogin(@RequestBody FormLoginRequest req, HttpServletResponse httpServletResponse) {
         return ResponseEntity.ok(authService.formLogin(req, httpServletResponse));
     }
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorization) {
+        authService.logout(authorization);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/nocap/auth/controller/AuthSwagger.java
+++ b/src/main/java/com/example/nocap/auth/controller/AuthSwagger.java
@@ -119,4 +119,12 @@ public interface AuthSwagger {
             }
     )
     ResponseEntity<?> formLogin(FormLoginRequest req, HttpServletResponse httpServletResponse);
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 토큰을 블랙리스트로 설정. 블랙리스트에서 60분 이후 삭제. 레디스가 아닌 메모리 형식으로 구현되어 있음",
+            parameters = { @Parameter(name = "Authorization", description = "Bearer {Access Token}", required = true) },
+            responses = { @ApiResponse(responseCode = "204", description = "로그아웃 완료") }
+    )
+    ResponseEntity<Void> logout(String authorization);
+
 }

--- a/src/main/java/com/example/nocap/auth/service/AuthService.java
+++ b/src/main/java/com/example/nocap/auth/service/AuthService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -26,6 +27,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
+    private final TokenBlacklist tokenBlacklist;
 
     public UserResponse oAuthLogin(String accessCode, HttpServletResponse httpServletResponse) {
         String accessToken = kakaoUtil.getAccessTokenFromKakao(accessCode);
@@ -91,5 +93,10 @@ public class AuthService {
         String token = jwtUtil.createJwt(user, 60 * 60 * 1000L);
         httpServletResponse.setHeader("Authorization", "Bearer " + token);
         return new UserResponse(user, true);
+    }
+    public void logout(String authorization) {
+        String token = authorization.startsWith("Bearer ") ? authorization.substring(7) : authorization;
+        Date exp = jwtUtil.getExpiration(token);
+        tokenBlacklist.blacklist(token, exp.getTime());
     }
 }

--- a/src/main/java/com/example/nocap/auth/service/TokenBlacklist.java
+++ b/src/main/java/com/example/nocap/auth/service/TokenBlacklist.java
@@ -1,0 +1,25 @@
+package com.example.nocap.auth.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+/* 캐시에 블랙리스트 저장 (도메인 확장이나 나중에는 Redis 권장)
+    캐시 메모리에 최대 10만개의 토큰 저장, 저장된 토큰이 60분 이상 되었다면 삭제 - 토큰의 유효 시간과 일치
+ */
+@Component
+public class TokenBlacklist {
+    private final Cache<String, Boolean> cache = Caffeine.newBuilder()
+            .maximumSize(100_000)
+            .expireAfterWrite(60, TimeUnit.MINUTES)
+            .build();
+
+    public void blacklist(String token, long expiresAtMillis) {
+        long ttlMs = expiresAtMillis - System.currentTimeMillis();
+        if (ttlMs > 0) cache.put(token, Boolean.TRUE);
+    }
+    public boolean isBlacklisted(String token) {
+        return cache.getIfPresent(token) != null;
+    }
+}

--- a/src/main/java/com/example/nocap/global/WebClientConfig.java
+++ b/src/main/java/com/example/nocap/global/WebClientConfig.java
@@ -11,14 +11,15 @@ public class WebClientConfig {
     @Value("${fastapi.server.url}")
     private String fastapiUrl;
 
-    @Value("${fastapi.server.api-key}")
-    private String fastApiKey;
+//    @Value("${fastapi.server.api-key}")
+//    private String fastApiKey;
 
     @Bean
     public WebClient webClient() {
         return WebClient.builder()
             .baseUrl(fastapiUrl) // 모든 요청의 기본 URL을 FastAPI 서버 주소로 설정
-            .defaultHeader("X-API-KEY", fastApiKey)
+//            .defaultHeader("X-API-KEY", fastApiKey)
+            .defaultHeader("X-API-KEY")
             .build();
     }
 }


### PR DESCRIPTION
- 로그아웃 기능 구현
- 캐시메모리를 사용하여 최대 10만개까지 토큰(블랙리스트) 저장 && 한시간 후 자동 삭제
- 로그아웃 성공시 반환 메세지 변경 예정
<img width="1515" height="885" alt="image" src="https://github.com/user-attachments/assets/0921ca2e-2500-40a1-8057-af351f57eed5" />
<img width="1477" height="913" alt="image" src="https://github.com/user-attachments/assets/1fa6be14-99f3-4468-abfe-7fc41b09ee44" />
로그아웃된 토큰으로 접근하려 할 경우 401이 뜨게 된다. 