### PR TITLE
Refactor/crawling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 
 
     //swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.12'
     constraints {
         implementation("io.swagger.core.v3:swagger-annotations-jakarta:2.2.36")
         implementation("io.swagger.core.v3:swagger-models-jakarta:2.2.36")

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.3'
+     id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -73,7 +73,7 @@ dependencies {
 
 
     //swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.12'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     constraints {
         implementation("io.swagger.core.v3:swagger-annotations-jakarta:2.2.36")
         implementation("io.swagger.core.v3:swagger-models-jakarta:2.2.36")

--- a/src/main/java/com/example/nocap/NocapApplication.java
+++ b/src/main/java/com/example/nocap/NocapApplication.java
@@ -2,8 +2,10 @@ package com.example.nocap;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class NocapApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
             "/api/nocap/analysis/{id:\\d+}",
             "/api/nocap/analysis/keyword/{keyword}",
             "/api/nocap/search/**",
+            "/api/nocap/search/**/**",
             "/auth/kakao/**", "/auth/login/kakao", "/auth/form/**", "/swagger-ui/**",
             "/v3/api-docs/**", "/swagger-resources/**",
             "/api/nocap/analysis/healthCheck", // 헬스 체크

--- a/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.nocap.auth.config;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,15 +12,12 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -38,7 +36,7 @@ public class SecurityConfig {
             "/api/nocap/analysis/{id:\\d+}",
             "/api/nocap/analysis/keyword/{keyword}",
             "/api/nocap/search/**",
-            "/api/nocap/popnews", "/swagger-ui.html", "/webjars/**",
+            "/api/nocap/popnews", "/swagger-ui/**", "/webjars/**",
 
     };
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 
             "/api/nocap/analysis/{id:\\d+}",
             "/api/nocap/analysis/keyword/{keyword}",
-            "/api/nocap/search/**"
+            "/api/nocap/search/**",
             "/auth/kakao/**", "/auth/login/kakao", "/auth/form/**", "/swagger-ui/**",
             "/v3/api-docs/**", "/swagger-resources/**",
             "/api/nocap/analysis/healthCheck", // 헬스 체크

--- a/src/main/java/com/example/nocap/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/example/nocap/domain/analysis/controller/AnalysisController.java
@@ -7,6 +7,8 @@ import com.example.nocap.domain.analysis.dto.AnalysisViewDto;
 import com.example.nocap.domain.analysis.dto.SbertResponseDto;
 import com.example.nocap.domain.analysis.service.AnalysisProcessService;
 import com.example.nocap.domain.analysis.service.AnalysisService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-
+@Tag(name = "Analysis", description = "분석 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/nocap/analysis")
@@ -30,6 +32,11 @@ public class AnalysisController {
     private final AnalysisProcessService analysisProcessService;
     private final AnalysisService analysisService;
 
+    @Operation(
+        summary = "FastAPI 헬스체크",
+        description = "FastAPI 서버와의 연결을 확인.",
+        responses = { /* ... */ }
+    )
     @GetMapping("/healthCheck")
     public ResponseEntity<Void> healthCheck() {
         boolean isHealthy = analysisProcessService.healthCheck();
@@ -43,6 +50,11 @@ public class AnalysisController {
         }
     }
 
+    @Operation(
+        summary = "Analysis 수행",
+        description = "사용자의 id와 분석할 기사의 url을 통해 분석을 수행.",
+        responses = { /* ... */ }
+    )
     @PostMapping
     public ResponseEntity<SbertResponseDto> analysis (@RequestBody AnalysisRequestDto analysisRequestDto) {
 
@@ -52,26 +64,51 @@ public class AnalysisController {
         return ResponseEntity.ok(sbertRequestDto);
     }
 
+    @Operation(
+        summary = "모든 분석 조회",
+        description = "수행된 모든 분석을 조회.",
+        responses = { /* ... */ }
+    )
     @GetMapping
     public ResponseEntity<List<AnalysisDto>> getAllAnalysis() {
         return ResponseEntity.ok(analysisService.getAllAnalysis());
     }
 
+    @Operation(
+        summary = "특정 분석 조회",
+        description = "분석 id를 통해 특정 분석 하나를 조회.",
+        responses = { /* ... */ }
+    )
     @GetMapping("/{id}")
     public ResponseEntity<AnalysisViewDto> getAnalysisById(@PathVariable Long id) {
         return ResponseEntity.ok(analysisService.getAnalysisById(id));
     }
 
+    @Operation(
+        summary = "카테고리별 분석 조회",
+        description = "요청된 카테고리에 맞는 분석을 조회.",
+        responses = { /* ... */ }
+    )
     @GetMapping("category/{category}")
     public ResponseEntity<List<AnalysisDto>> getAnalysisByCategory(@PathVariable String category) {
         return ResponseEntity.ok(analysisService.getAnalysisByCategory(category));
     }
 
+    @Operation(
+        summary = "내 분석 조회",
+        description = "내가 수행한 분석 조회.",
+        responses = { /* ... */ }
+    )
     @GetMapping("/my")
     public ResponseEntity<List<AnalysisDto>> getAnalysisByUserId(@AuthenticationPrincipal UserDetail userDetail) { 
         return ResponseEntity.ok(analysisService.getAnalysisByUserId(userDetail));
     }
 
+    @Operation(
+        summary = "특정 분석 삭제",
+        description = "분석 id를 통해 특정 분석을 삭제.",
+        responses = { /* ... */ }
+    )
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteAnalysisById(@PathVariable Long id) {
         analysisService.deleteAnalysisById(id);

--- a/src/main/java/com/example/nocap/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/example/nocap/domain/analysis/controller/AnalysisController.java
@@ -8,6 +8,7 @@ import com.example.nocap.domain.analysis.dto.SbertResponseDto;
 import com.example.nocap.domain.analysis.service.AnalysisProcessService;
 import com.example.nocap.domain.analysis.service.AnalysisService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +54,8 @@ public class AnalysisController {
     @Operation(
         summary = "Analysis 수행",
         description = "사용자의 id와 분석할 기사의 url을 통해 분석을 수행.",
+        parameters = { @Parameter(name = "userId", description = "사용자 ID", required = true, example = "1"),
+                       @Parameter(name = "url", description = "분석할 뉴스 URL", required = true, example = "https://n.news.naver.com/article/366/0001111339?cds=news_media_pc")},
         responses = { /* ... */ }
     )
     @PostMapping
@@ -77,6 +80,7 @@ public class AnalysisController {
     @Operation(
         summary = "특정 분석 조회",
         description = "분석 id를 통해 특정 분석 하나를 조회.",
+        parameters = { @Parameter(name = "id", description = "분석 ID", required = true, example = "1"),},
         responses = { /* ... */ }
     )
     @GetMapping("/{id}")
@@ -87,6 +91,7 @@ public class AnalysisController {
     @Operation(
         summary = "카테고리별 분석 조회",
         description = "요청된 카테고리에 맞는 분석을 조회.",
+        parameters = { @Parameter(name = "category", description = "분석 카테고리", required = true, example = "사회"),},
         responses = { /* ... */ }
     )
     @GetMapping("category/{category}")
@@ -107,6 +112,7 @@ public class AnalysisController {
     @Operation(
         summary = "특정 분석 삭제",
         description = "분석 id를 통해 특정 분석을 삭제.",
+        parameters = { @Parameter(name = "id", description = "분석 ID", required = true, example = "1"),},
         responses = { /* ... */ }
     )
     @DeleteMapping("/{id}")

--- a/src/main/java/com/example/nocap/domain/analysis/dto/AnalysisViewDto.java
+++ b/src/main/java/com/example/nocap/domain/analysis/dto/AnalysisViewDto.java
@@ -1,7 +1,8 @@
 package com.example.nocap.domain.analysis.dto;
 
 import com.example.nocap.domain.analysis.dto.SbertResponseDto.NewsComparisonDto;
-import com.example.nocap.domain.mainnews.dto.MainNewsDto;
+import com.example.nocap.domain.mainnews.dto.MainNewsRequestDto;
+import com.example.nocap.domain.mainnews.dto.MainNewsResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Data;
@@ -15,7 +16,7 @@ public class AnalysisViewDto {
     private Long view;
     private LocalDateTime date;
     private String image; // MainNews의 image url
-    private MainNewsDto mainNewsDto;
+    private MainNewsResponseDto mainNewsDto;
     private List<NewsComparisonDto> newsComparisonDtos;
 
 }

--- a/src/main/java/com/example/nocap/domain/analysis/dto/CrawledResponseDto.java
+++ b/src/main/java/com/example/nocap/domain/analysis/dto/CrawledResponseDto.java
@@ -1,6 +1,6 @@
 package com.example.nocap.domain.analysis.dto;
 
-import com.example.nocap.domain.news.dto.NewsDto;
+import com.example.nocap.domain.news.dto.NewsRequestDto;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
@@ -9,6 +9,6 @@ import lombok.Data;
 @Builder
 public class CrawledResponseDto {
 
-    private List<NewsDto> newsDtos;
+    private List<NewsRequestDto> newsDtos;
 
 }

--- a/src/main/java/com/example/nocap/domain/analysis/dto/SbertRequestDto.java
+++ b/src/main/java/com/example/nocap/domain/analysis/dto/SbertRequestDto.java
@@ -1,7 +1,7 @@
 package com.example.nocap.domain.analysis.dto;
 
-import com.example.nocap.domain.mainnews.dto.MainNewsDto;
-import com.example.nocap.domain.news.dto.NewsDto;
+import com.example.nocap.domain.mainnews.dto.MainNewsRequestDto;
+import com.example.nocap.domain.news.dto.NewsRequestDto;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
@@ -12,7 +12,7 @@ public class SbertRequestDto {
 
     private String plan;
     private String category;
-    private MainNewsDto mainNewsDto;
-    private List<NewsDto> newsDtos;
+    private MainNewsRequestDto mainNewsDto;
+    private List<NewsRequestDto> newsDtos;
 
 }

--- a/src/main/java/com/example/nocap/domain/analysis/dto/SbertResponseDto.java
+++ b/src/main/java/com/example/nocap/domain/analysis/dto/SbertResponseDto.java
@@ -1,7 +1,8 @@
 package com.example.nocap.domain.analysis.dto;
 
-import com.example.nocap.domain.mainnews.dto.MainNewsDto;
-import com.example.nocap.domain.news.dto.NewsDto;
+import com.example.nocap.domain.mainnews.dto.MainNewsResponseDto;
+import com.example.nocap.domain.news.dto.NewsRequestDto;
+import com.example.nocap.domain.news.dto.NewsResponseDto;
 import java.util.ArrayList;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -15,7 +16,7 @@ import java.util.List;
 public class SbertResponseDto {
 
     private String category;
-    private MainNewsDto mainNewsDto;
+    private MainNewsResponseDto mainNewsDto;
     private List<NewsComparisonDto> newsComparisonDtos = new ArrayList<>();
 
     @Data
@@ -30,6 +31,6 @@ public class SbertResponseDto {
     @AllArgsConstructor
     public static class NewsWithSimilarityDto {
         private double similarity;
-        private NewsDto newsDto;
+        private NewsResponseDto newsDto;
     }
 }

--- a/src/main/java/com/example/nocap/domain/analysis/service/AnalysisProcessService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/AnalysisProcessService.java
@@ -9,7 +9,6 @@ import com.example.nocap.domain.analysis.dto.SbertResponseDto;
 import com.example.nocap.domain.analysis.dto.TitleCategoryDto;
 import com.example.nocap.domain.analysis.entity.Analysis;
 import com.example.nocap.domain.analysis.mapper.AnalysisMapper;
-import com.example.nocap.domain.analysis.repository.AnalysisRepository;
 import com.example.nocap.domain.mainnews.entity.MainNews;
 import com.example.nocap.domain.mainnews.mapper.MainNewsMapper;
 import com.example.nocap.domain.mainnews.repository.MainNewsRepository;
@@ -18,12 +17,10 @@ import com.example.nocap.domain.user.entity.User;
 import com.example.nocap.domain.user.repository.UserRepository;
 import com.example.nocap.exception.CustomException;
 import com.example.nocap.exception.ErrorCode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -89,8 +86,8 @@ public class AnalysisProcessService {
                 SbertRequestDto sbertRequestDto = SbertRequestDto.builder()
                     .plan(plan)
                     .category(existingAnalysis.getCategory())
-                    .mainNewsDto(mainNewsMapper.toMainNewsDto(mainNews))
-                    .newsDtos(newsMapper.toNewsDtoList(existingAnalysis.getRelatedNews()))
+                    .mainNewsDto(mainNewsMapper.toMainNewsRequestDto(mainNews))
+                    .newsDtos(newsMapper.toNewsRequestDtoList(existingAnalysis.getRelatedNews()))
                     .build();
                 SbertResponseDto sbertResponseDto = requestFastAPi(sbertRequestDto);
                 // 비교를 갱신하여 다시 저장
@@ -134,7 +131,7 @@ public class AnalysisProcessService {
         SbertRequestDto sbertRequestDto = SbertRequestDto.builder()
             .plan(plan)
             .category(titleCategoryDto.getCategory())
-            .mainNewsDto(mainNewsMapper.toMainNewsDto(mainNews))
+            .mainNewsDto(mainNewsMapper.toMainNewsRequestDto(mainNews))
             .newsDtos(crawledResponseDto.getNewsDtos())
             .build();
 
@@ -148,6 +145,7 @@ public class AnalysisProcessService {
 
     private SbertResponseDto requestFastAPi(SbertRequestDto sbertRequestDto) {
         SbertResponseDto sbertResponseDto;
+
         try {
             return sbertResponseDto = webClient.post() // POST 요청
                 .uri("/analyze") //FastAPI 서버의 엔드포인트 경로

--- a/src/main/java/com/example/nocap/domain/analysis/service/AnalysisSaveService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/AnalysisSaveService.java
@@ -5,23 +5,22 @@ import com.example.nocap.domain.analysis.dto.SbertResponseDto.NewsComparisonDto;
 import com.example.nocap.domain.analysis.entity.Analysis;
 import com.example.nocap.domain.analysis.repository.AnalysisRepository;
 import com.example.nocap.domain.mainnews.entity.MainNews;
-import com.example.nocap.domain.news.dto.NewsDto;
 import com.example.nocap.domain.news.entity.News;
+import com.example.nocap.domain.news.mapper.NewsMapper;
 import com.example.nocap.domain.user.entity.User;
 import com.example.nocap.domain.user.repository.UserRepository;
 import com.example.nocap.domain.useranalysis.entity.UserAnalysis;
 import com.example.nocap.domain.useranalysis.repository.UserAnalysisRepository;
 import com.example.nocap.exception.CustomException;
 import com.example.nocap.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +29,7 @@ public class AnalysisSaveService {
     private final UserRepository userRepository;
     private final AnalysisRepository analysisRepository;
     private final UserAnalysisRepository userAnalysisRepository;
+    private final NewsMapper newsMapper;
 
     @Transactional
     public void saveAnalysisData(Long userId, MainNews mainNews, SbertResponseDto sbertResponseDto) {
@@ -42,22 +42,15 @@ public class AnalysisSaveService {
             .date(LocalDateTime.now())
             .version(user.getRole())
             .build();
-
+        mainNews.setPhrases(sbertResponseDto.getMainNewsDto().getPhrases());
         analysis.setMainNews(mainNews);
 
         if (sbertResponseDto.getNewsComparisonDtos() != null) {
-            List<News> relatedNewsList = sbertResponseDto.getNewsComparisonDtos().stream()
-                .map(compDto -> {
-                    NewsDto newsDto = compDto.getNewsWithSimilarityDto().getNewsDto();
-                    return News.builder()
-                        .url(newsDto.getUrl())
-                        .title(newsDto.getTitle())
-                        .content(newsDto.getContent())
-                        .similarity(compDto.getNewsWithSimilarityDto().getSimilarity())
-                        .comparison(compDto.getComparison())
-                        .build();
-                })
-                .collect(Collectors.toList());
+            List<News> relatedNewsList = newsMapper.sbertDtoListToEntityList(sbertResponseDto.getNewsComparisonDtos());
+
+            // 부모-자식 관계 설정
+            relatedNewsList.forEach(news -> news.setAnalysis(analysis));
+
             analysis.setRelatedNews(relatedNewsList);
         }
 

--- a/src/main/java/com/example/nocap/domain/analysis/service/ArticleExtractionService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/ArticleExtractionService.java
@@ -6,6 +6,9 @@ import com.example.nocap.exception.ErrorCode;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,45 +24,129 @@ public class ArticleExtractionService {
 
     public MainNews extract(String url) {
         try {
-            Document doc = Jsoup.connect(url)
-                .userAgent("Mozilla/5.0")
-                .timeout(5_000)
-                .get();
-
-            // 기사 여부 판별 로직
+            Document doc = Jsoup.connect(url).get();
             if (!isArticleByConfidenceScore(doc)) {
-                // 변경점 1: 기사가 아닐 때 Exception 발생
                 throw new CustomException(ErrorCode.NOT_A_NEWS_ARTICLE);
             }
 
-            String canonicalUrl = "";
-            Element canonicalLink = doc.selectFirst("link[rel=canonical]");
-            if (canonicalLink != null && canonicalLink.hasAttr("href")) {
-                canonicalUrl = canonicalLink.attr("href");
-            } else {
-                canonicalUrl = normalizeUrl(url);
-            }
+            preprocessDocument(doc);
 
-            Element ogImageElement = doc.selectFirst("meta[property=og:image]");
-            String ogImage = (ogImageElement != null) ? ogImageElement.attr("content") : "";
+            String ogTitle = getMetaTagContent(doc, "og:title");
+            String ogImage = getMetaTagContent(doc, "og:image");
 
             Article article = new Readability4J(url, doc.html()).parse();
-
             String htmlContent = article.getContent();
-            String plainContent = Jsoup.parse(htmlContent).text();
+
+            String finalTitle = (!ogTitle.isEmpty()) ? ogTitle : article.getTitle();
+            finalTitle = unescape(finalTitle);
+
+            String pubDateString = extractPublishedDate(doc);
+            String pubDate = parseDateString(pubDateString); // String -> LocalDateTime 변환
+
+            String canonicalUrl = createCanonicalUrl(doc, url); // 정규화 로직 적용
 
             return MainNews.builder()
                 .url(url)
                 .canonicalUrl(canonicalUrl)
-                .title(article.getTitle())
-                .content(plainContent)
+                .title(finalTitle)
+                .content(htmlContent)
                 .image(ogImage)
+                .date(pubDate)
                 .build();
 
         } catch (IOException e) {
-            // 변경점 2: Jsoup 연결 실패 시 Exception 발생
             throw new CustomException(ErrorCode.EXTERNAL_API_ERROR);
         }
+    }
+
+    private String createCanonicalUrl(Document doc, String originalUrl) {
+        // 1순위: og:url
+        String ogUrl = getMetaTagContent(doc, "og:url");
+        if (!ogUrl.isEmpty()) {
+            return ogUrl;
+        }
+        // 2순위: link[rel=canonical]
+        Element canonicalLink = doc.selectFirst("link[rel=canonical]");
+        if (canonicalLink != null && canonicalLink.hasAttr("href")) {
+            return canonicalLink.attr("href");
+        }
+        // 3순위: normalizeUrl
+        return normalizeUrl(originalUrl);
+    }
+
+    private void preprocessDocument(Document doc) {
+        doc.select(".read_cont, em.img_desc, span.img_desc, .desc_thumb").remove();
+    }
+
+    private String unescape(String text) {
+        if (text == null) return null;
+        return text.replace("\\\"", "\"").replace("\\'", "'");
+    }
+
+    private String getMetaTagContent(Document doc, String property) {
+        Element metaTag = doc.selectFirst("meta[property=" + property + "]");
+        return (metaTag != null) ? metaTag.attr("content") : "";
+    }
+
+    private String extractPublishedDate(Document doc) {
+        // 우선순위대로 날짜를 포함할 가능성이 높은 선택자 목록
+        String[] dateSelectors = {
+            "meta[property=article:published_time]", // 1순위: 국제 표준 메타 태그
+            "span.num_date",
+            "span._ARTICLE_DATE_TIME",              // 2순위: 네이버 뉴스
+            "span.t11",                             // 3순위: 네이버 뉴스 (구버전)
+            "span[class*='date']",                  // 4순위: 'date' 클래스를 포함하는 span
+            "time"                                  // 5순위: <time> 태그
+        };
+
+        for (String selector : dateSelectors) {
+            Element dateElement = doc.selectFirst(selector);
+            if (dateElement != null) {
+                if (dateElement.hasAttr("content")) return dateElement.attr("content");
+                if (dateElement.hasAttr("data-date-time")) return dateElement.attr("data-date-time");
+                return dateElement.text();
+            }
+        }
+        return null; // 날짜를 찾지 못한 경우
+    }
+
+    private String parseDateString(String dateString) {
+        if (dateString == null || dateString.isBlank()) {
+            return null;
+        }
+
+        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd"); // ✨ 최종 출력 형식
+
+        List<DateTimeFormatter> formatters = List.of(
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+            DateTimeFormatter.RFC_1123_DATE_TIME,
+            DateTimeFormatter.ofPattern("yyyy. M. d. HH:mm"),
+            DateTimeFormatter.ofPattern("yyyy.MM.dd. a H:mm"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        );
+
+        for (DateTimeFormatter formatter : formatters) {
+            try {
+                // 시간대 정보가 포함된 형식(RFC, ISO)은 ZonedDateTime으로 파싱
+                return ZonedDateTime.parse(dateString, formatter).format(outputFormatter);
+            } catch (java.time.format.DateTimeParseException e1) {
+                try {
+                    // 시간대 정보가 없는 형식은 LocalDateTime으로 파싱
+                    return LocalDateTime.parse(dateString, formatter).format(outputFormatter);
+                } catch (java.time.format.DateTimeParseException e2) {
+                    // 둘 다 실패하면 다음 포맷터로 계속
+                }
+            }
+        }
+
+        // 정규식으로 'YYYY-MM-DD' 또는 'YYYY.MM.DD' 형태만 추출 시도
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("\\d{4}[-.]\\d{2}[-.]\\d{2}");
+        java.util.regex.Matcher matcher = pattern.matcher(dateString);
+        if (matcher.find()) {
+            return matcher.group(0).replace(".", "-");
+        }
+
+        return null; // 모든 형식에 실패하면 null 반환
     }
 
     private boolean isArticleByConfidenceScore(Document doc) {

--- a/src/main/java/com/example/nocap/domain/mainnews/dto/MainNewsRequestDto.java
+++ b/src/main/java/com/example/nocap/domain/mainnews/dto/MainNewsRequestDto.java
@@ -1,17 +1,20 @@
-package com.example.nocap.domain.news.dto;
+package com.example.nocap.domain.mainnews.dto;
 
 import jakarta.persistence.Column;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-@AllArgsConstructor
-public class NewsDto {
+public class MainNewsRequestDto {
 
     private String url;
 
     private String title;
 
+    private String date;
+
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    private String image;
+
 }

--- a/src/main/java/com/example/nocap/domain/mainnews/dto/MainNewsResponseDto.java
+++ b/src/main/java/com/example/nocap/domain/mainnews/dto/MainNewsResponseDto.java
@@ -1,17 +1,21 @@
 package com.example.nocap.domain.mainnews.dto;
 
 import jakarta.persistence.Column;
+import java.util.List;
 import lombok.Data;
 
 @Data
-public class MainNewsDto {
+public class MainNewsResponseDto {
 
     private String url;
 
     private String title;
 
+    private String date;
+
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    private List<String> phrases;;
 
 }

--- a/src/main/java/com/example/nocap/domain/mainnews/entity/MainNews.java
+++ b/src/main/java/com/example/nocap/domain/mainnews/entity/MainNews.java
@@ -1,7 +1,17 @@
 package com.example.nocap.domain.mainnews.entity;
 
 import com.example.nocap.domain.analysis.entity.Analysis;
-import jakarta.persistence.*;
+import com.example.nocap.global.StringListConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,8 +38,14 @@ public class MainNews {
 
     private String title;
 
+    private String date;
+
     @Column(columnDefinition = "TEXT")
     private String content;
 
     private String image;
+
+    @Column(columnDefinition = "LONGTEXT")
+    @Convert(converter = StringListConverter.class)
+    private List<String> phrases;
 }

--- a/src/main/java/com/example/nocap/domain/mainnews/mapper/MainNewsMapper.java
+++ b/src/main/java/com/example/nocap/domain/mainnews/mapper/MainNewsMapper.java
@@ -1,8 +1,10 @@
 package com.example.nocap.domain.mainnews.mapper;
 
-import com.example.nocap.domain.mainnews.dto.MainNewsDto;
+import com.example.nocap.domain.mainnews.dto.MainNewsRequestDto;
+import com.example.nocap.domain.mainnews.dto.MainNewsResponseDto;
 import com.example.nocap.domain.mainnews.entity.MainNews;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring")
@@ -10,6 +12,6 @@ public interface MainNewsMapper {
 
     MainNewsMapper INSTANCE = Mappers.getMapper(MainNewsMapper.class);
 
-    MainNewsDto toMainNewsDto(MainNews mainNews);
-
+    MainNewsRequestDto toMainNewsRequestDto(MainNews mainNews);
+    MainNewsResponseDto toMainNewsResponseDto(MainNews mainNews);
 }

--- a/src/main/java/com/example/nocap/domain/news/dto/NewsRequestDto.java
+++ b/src/main/java/com/example/nocap/domain/news/dto/NewsRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.nocap.domain.news.dto;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class NewsRequestDto {
+
+    private String url;
+
+    private String title;
+
+    private String date;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+}

--- a/src/main/java/com/example/nocap/domain/news/dto/NewsResponseDto.java
+++ b/src/main/java/com/example/nocap/domain/news/dto/NewsResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.nocap.domain.news.dto;
+
+import jakarta.persistence.Column;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class NewsResponseDto {
+
+    private String url;
+
+    private String title;
+
+    private String date;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private List<String> phrases;
+}

--- a/src/main/java/com/example/nocap/domain/news/entity/News.java
+++ b/src/main/java/com/example/nocap/domain/news/entity/News.java
@@ -1,7 +1,9 @@
 package com.example.nocap.domain.news.entity;
 
 import com.example.nocap.domain.analysis.entity.Analysis;
+import com.example.nocap.global.StringListConverter;
 import jakarta.persistence.*;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -25,6 +27,8 @@ public class News {
 
     private String title;
 
+    private String date;
+
     @Column(columnDefinition = "TEXT")
     private String content;
 
@@ -32,4 +36,8 @@ public class News {
 
     @Column(columnDefinition = "TEXT")
     private String comparison;
+
+    @Column(columnDefinition = "LONGTEXT")
+    @Convert(converter = StringListConverter.class)
+    private List<String> phrases;
 }

--- a/src/main/java/com/example/nocap/domain/news/mapper/NewsMapper.java
+++ b/src/main/java/com/example/nocap/domain/news/mapper/NewsMapper.java
@@ -3,7 +3,8 @@ package com.example.nocap.domain.news.mapper;
 import com.example.nocap.domain.analysis.dto.SbertResponseDto;
 import com.example.nocap.domain.analysis.dto.SbertResponseDto.NewsComparisonDto;
 import com.example.nocap.domain.analysis.dto.SbertResponseDto.NewsWithSimilarityDto;
-import com.example.nocap.domain.news.dto.NewsDto;
+import com.example.nocap.domain.news.dto.NewsRequestDto;
+import com.example.nocap.domain.news.dto.NewsResponseDto;
 import com.example.nocap.domain.news.entity.News;
 import java.util.List;
 import org.mapstruct.Mapper;
@@ -22,9 +23,10 @@ public interface NewsMapper {
     @Mapping(source = "similarity", target = "similarity") // 4. similarity 필드는 이름이 같으니 그대로 매핑
     NewsWithSimilarityDto toNewsWithSimilarityDto(News news);
 
-    NewsDto toNewsDto(News news);
+    NewsRequestDto toNewsRequestDto(News news);
+    NewsResponseDto toNewsResponseDto(News news);
 
-    List<NewsDto> toNewsDtoList(List<News> newsList);
+    List<NewsRequestDto> toNewsRequestDtoList(List<News> newsList);
 
 
     @Named("Sbert")
@@ -32,4 +34,19 @@ public interface NewsMapper {
     @Mapping(source = ".", target = "newsWithSimilarityDto.newsDto")
     @Mapping(source = "comparison", target = "comparison")
     SbertResponseDto.NewsComparisonDto toSbertNewsComparisonDto(News news);
+
+    // SBERT 응답 DTO -> News Entity 변환
+    @Mapping(source = "newsWithSimilarityDto.newsDto.url", target = "url")
+    @Mapping(source = "newsWithSimilarityDto.newsDto.title", target = "title")
+    @Mapping(source = "newsWithSimilarityDto.newsDto.content", target = "content")
+    @Mapping(source = "newsWithSimilarityDto.newsDto.date", target = "date")
+    @Mapping(source = "newsWithSimilarityDto.newsDto.phrases", target = "phrases")
+    @Mapping(source = "newsWithSimilarityDto.similarity", target = "similarity")
+    @Mapping(source = "comparison", target = "comparison")
+    @Mapping(target = "newsId", ignore = true) // DB에서 자동 생성되므로 매핑 제외
+    @Mapping(target = "analysis", ignore = true) // 나중에 서비스에서 설정
+    News sbertDtoToEntity(NewsComparisonDto dto);
+
+    // SBERT 응답 DTO 리스트 -> News Entity 리스트 변환
+    List<News> sbertDtoListToEntityList(List<NewsComparisonDto> dtoList);
 }

--- a/src/main/java/com/example/nocap/domain/popnews/controller/PopNewsController.java
+++ b/src/main/java/com/example/nocap/domain/popnews/controller/PopNewsController.java
@@ -3,6 +3,7 @@ package com.example.nocap.domain.popnews.controller;
 import com.example.nocap.domain.popnews.dto.PopNewsDto;
 import com.example.nocap.domain.popnews.service.PopNewsService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/example/nocap/domain/popnews/controller/PopNewsController.java
+++ b/src/main/java/com/example/nocap/domain/popnews/controller/PopNewsController.java
@@ -2,6 +2,7 @@ package com.example.nocap.domain.popnews.controller;
 
 import com.example.nocap.domain.popnews.dto.PopNewsDto;
 import com.example.nocap.domain.popnews.service.PopNewsService;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +17,11 @@ public class PopNewsController {
 
     private final PopNewsService popNewsService;
 
-    //@Operation(summary="인기뉴스 조회", description="하루 단위로 갱신되는 인기 뉴스를 조회합니다.")
+    @Operation(
+        summary = "인기뉴스 조회",
+        description = "하루 주기로 갱신되는 인기뉴스 조회",
+        responses = { /* ... */ }
+    )
     @GetMapping
     public ResponseEntity<List<PopNewsDto>> getPopNews() {
         return ResponseEntity.ok(popNewsService.getPopNews());

--- a/src/main/java/com/example/nocap/domain/popnews/dto/PopNewsDto.java
+++ b/src/main/java/com/example/nocap/domain/popnews/dto/PopNewsDto.java
@@ -14,5 +14,6 @@ public class PopNewsDto {
     private String content;
 
     private String image;
+    private String date;
 
 }

--- a/src/main/java/com/example/nocap/domain/popnews/entity/PopNews.java
+++ b/src/main/java/com/example/nocap/domain/popnews/entity/PopNews.java
@@ -30,5 +30,7 @@ public class PopNews {
 
     private String image;
 
+    private String date;
+
 
 }

--- a/src/main/java/com/example/nocap/domain/popnews/service/PopNewsService.java
+++ b/src/main/java/com/example/nocap/domain/popnews/service/PopNewsService.java
@@ -37,6 +37,7 @@ public class PopNewsService {
     @Transactional
     @Scheduled(cron = "0 0 4 * * ?")
     public void requestPopNews() {
+        System.out.println("인기뉴스 크롤링이 수행됩니다.");
 
         // 배포시에는 살려야할 부분과 서버에 설치해야되는 것들
         // System.setProperty("webdriver.chrome.driver", "/usr/bin/chromedriver");
@@ -84,6 +85,7 @@ public class PopNewsService {
                             .title(extractedArticle.getTitle())
                             .content(extractedArticle.getContent())
                             .image(extractedArticle.getImage())
+                                .date(extractedArticle.getDate())
                             .build());
                     }
                 } catch (Exception e) {

--- a/src/main/java/com/example/nocap/domain/searchnews/controller/SearchNewsController.java
+++ b/src/main/java/com/example/nocap/domain/searchnews/controller/SearchNewsController.java
@@ -3,6 +3,7 @@ package com.example.nocap.domain.searchnews.controller;
 import com.example.nocap.domain.searchnews.dto.SearchNewsDto;
 import com.example.nocap.domain.searchnews.service.SearchNewsService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class SearchNewsController {
     @Operation(
         summary = "카테고리별 뉴스 검색",
         description = "카테고리 번호 100-104에 따라 정치, 경제, 사회, 생활/문화, 세계, IT/과학 뉴스 조회.",
+        parameters = { @Parameter(name = "category", description = "뉴스 카테고리", required = true, example = "102"),},
         responses = { /* ... */ }
     )
     @GetMapping("category/{category}") // 100 - 104
@@ -33,6 +35,7 @@ public class SearchNewsController {
     @Operation(
         summary = "키워드별 뉴스 검색",
         description = "입력된 키워드를 통한 뉴스 조회.",
+        parameters = { @Parameter(name = "keyword", description = "뉴스 검색 키워드", required = true, example = "축구"),},
         responses = { /* ... */ }
     )
     @GetMapping("/keyword/{keyword}")

--- a/src/main/java/com/example/nocap/domain/searchnews/controller/SearchNewsController.java
+++ b/src/main/java/com/example/nocap/domain/searchnews/controller/SearchNewsController.java
@@ -2,6 +2,8 @@ package com.example.nocap.domain.searchnews.controller;
 
 import com.example.nocap.domain.searchnews.dto.SearchNewsDto;
 import com.example.nocap.domain.searchnews.service.SearchNewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "SearchNews", description = "뉴스 검색 API") // ✨ 1. @Tag 어노테이션 이동
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/nocap/search")
@@ -17,11 +20,21 @@ public class SearchNewsController {
 
     private final SearchNewsService searchNewsService;
 
+    @Operation(
+        summary = "카테고리별 뉴스 검색",
+        description = "카테고리 번호 100-104에 따라 정치, 경제, 사회, 생활/문화, 세계, IT/과학 뉴스 조회.",
+        responses = { /* ... */ }
+    )
     @GetMapping("category/{category}") // 100 - 104
     public ResponseEntity<List<SearchNewsDto>> getNewsByCategory(@PathVariable("category") int category) {
         return ResponseEntity.ok(searchNewsService.getNewsByCategory(category));
     }
 
+    @Operation(
+        summary = "키워드별 뉴스 검색",
+        description = "입력된 키워드를 통한 뉴스 조회.",
+        responses = { /* ... */ }
+    )
     @GetMapping("/keyword/{keyword}")
     public ResponseEntity<List<SearchNewsDto>> getNewsByKeyword(@PathVariable("keyword") String keyword) {
         return ResponseEntity.ok(searchNewsService.getNewsByKeyword(keyword));

--- a/src/main/java/com/example/nocap/global/StringListConverter.java
+++ b/src/main/java/com/example/nocap/global/StringListConverter.java
@@ -1,0 +1,39 @@
+package com.example.nocap.global;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        // List<String> -> JSON 문자열로 변환
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (Exception e) {
+            throw new RuntimeException("Error converting list to JSON", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        // JSON 문자열 -> List<String>으로 변환
+        if (dbData == null || dbData.isEmpty()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Error converting JSON to list", e);
+        }
+    }
+}


### PR DESCRIPTION
### 반영 브랜치
refactor/crawling -> develop

### 변경사항
- MainNews, News, PopNews에 String date "yyyy-DD-mm" 추가
- MainNews, News의 Dto에 대해 Response, Request로 구분
- Response의 경우 LongText로 저장되는 String phrases 추가
- phrases가 MainNew와 News에 1:N 테이블로 저장되기 않게하기 위한 StringListConverter 클래스 추가
- content 추출시 html 그대로 추출
- title에서 html 태그 제거
- Controller들에 대해 Swagger 설명 추가

### 테스트 결과
<img width="2020" height="1360" alt="image" src="https://github.com/user-attachments/assets/8ac8a04c-98ac-4745-a95c-6a22bf3b31a2" />

### 질문
- ROLE에 대해서 USER가 아니라 NORMAL과 PREMIUM으로 나눌 수 있는지?