### PR TITLE
Feat/history

### DIFF
--- a/src/main/java/com/example/nocap/domain/history/controller/HistoryController.java
+++ b/src/main/java/com/example/nocap/domain/history/controller/HistoryController.java
@@ -1,0 +1,64 @@
+package com.example.nocap.domain.history.controller;
+
+import com.example.nocap.auth.dto.response.UserDetail;
+import com.example.nocap.domain.history.dto.HistoryDetailDto;
+import com.example.nocap.domain.history.dto.HistoryRequestDto;
+import com.example.nocap.domain.history.dto.HistorySummaryDto;
+import com.example.nocap.domain.history.service.HistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/nocap/history")
+@RequiredArgsConstructor
+@Tag(name = "History", description = "뉴스 조회기록 관련 API")
+public class HistoryController {
+
+    private final HistoryService historyService;
+
+    @Operation(
+        summary = "조회기록 저장",
+        description = "로그인된 사용자가 뉴스를 조회할 때 해당 뉴스의 전체 정보를 저장",
+        responses = { /* ... */ }
+    )
+    @PostMapping("/record")
+    public ResponseEntity<HistoryRequestDto> saveHistory(
+        @RequestBody HistoryRequestDto historyRequestDto,
+        @AuthenticationPrincipal UserDetail userDetail) {
+        return ResponseEntity.ok(historyService.saveHistory(historyRequestDto, userDetail));
+    }
+
+    @Operation(
+        summary = "전체 조회기록 조회",
+        description = "로그인된 사용자가 자신의 최신 뉴스 조회기록 10개에 대한 정보 조회",
+        responses = { /* ... */ }
+    )
+    @GetMapping
+    public ResponseEntity<List<HistorySummaryDto>> getAllHistory(@AuthenticationPrincipal UserDetail userDetail) {
+        return ResponseEntity.ok(historyService.getAllHistory(userDetail));
+    }
+
+    @Operation(
+        summary = "특정 조회기록 조회",
+        description = "로그인된 사용자가 historyId를 통해 자신의 특정 뉴스 조회기록 한 개를 조회 ",
+        responses = { /* ... */ }
+    )
+    @GetMapping("/{historyId}")
+    public ResponseEntity<HistoryDetailDto> getHistory(
+        @PathVariable("historyId") Long historyId,
+        @AuthenticationPrincipal UserDetail userDetail) {
+        return ResponseEntity.ok(historyService.getHistory(historyId, userDetail));
+    }
+
+}

--- a/src/main/java/com/example/nocap/domain/history/dto/HistoryDetailDto.java
+++ b/src/main/java/com/example/nocap/domain/history/dto/HistoryDetailDto.java
@@ -1,0 +1,16 @@
+package com.example.nocap.domain.history.dto;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class HistoryDetailDto {
+
+    private Long id;
+    private String url;
+    private String title;
+    private String content;
+    private String date;
+    private String image;
+    private LocalDateTime viewDate;
+}

--- a/src/main/java/com/example/nocap/domain/history/dto/HistoryDetailDto.java
+++ b/src/main/java/com/example/nocap/domain/history/dto/HistoryDetailDto.java
@@ -12,5 +12,5 @@ public class HistoryDetailDto {
     private String content;
     private String date;
     private String image;
-    private LocalDateTime viewDate;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/nocap/domain/history/dto/HistoryRequestDto.java
+++ b/src/main/java/com/example/nocap/domain/history/dto/HistoryRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.nocap.domain.history.dto;
+
+import lombok.Data;
+
+@Data
+public class HistoryRequestDto {
+
+    private String url;
+    private String title;
+    private String content;
+    private String date;
+    private String image;
+
+}

--- a/src/main/java/com/example/nocap/domain/history/dto/HistorySummaryDto.java
+++ b/src/main/java/com/example/nocap/domain/history/dto/HistorySummaryDto.java
@@ -11,6 +11,6 @@ public class HistorySummaryDto {
     private String title;
     private String date;
     private String image;
-    private LocalDateTime viewDate;
+    private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/example/nocap/domain/history/dto/HistorySummaryDto.java
+++ b/src/main/java/com/example/nocap/domain/history/dto/HistorySummaryDto.java
@@ -1,0 +1,16 @@
+package com.example.nocap.domain.history.dto;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class HistorySummaryDto {
+
+    private Long id;
+    private String url;
+    private String title;
+    private String date;
+    private String image;
+    private LocalDateTime viewDate;
+
+}

--- a/src/main/java/com/example/nocap/domain/history/entity/History.java
+++ b/src/main/java/com/example/nocap/domain/history/entity/History.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Data
@@ -24,8 +25,11 @@ public class History {
     private User user;
 
     private String url;
-
     private String title;
+    private String content;
+    private String date;
+    private String image;
 
-    private LocalDateTime date;
+    @CreationTimestamp // 엔티티 생성 시 자동으로 현재 시간 저장
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/nocap/domain/history/entity/History.java
+++ b/src/main/java/com/example/nocap/domain/history/entity/History.java
@@ -26,6 +26,7 @@ public class History {
 
     private String url;
     private String title;
+    @Column(columnDefinition = "TEXT")
     private String content;
     private String date;
     private String image;

--- a/src/main/java/com/example/nocap/domain/history/mapper/HistoryMapper.java
+++ b/src/main/java/com/example/nocap/domain/history/mapper/HistoryMapper.java
@@ -1,0 +1,18 @@
+package com.example.nocap.domain.history.mapper;
+
+import com.example.nocap.domain.history.dto.HistoryDetailDto;
+import com.example.nocap.domain.history.dto.HistoryRequestDto;
+import com.example.nocap.domain.history.dto.HistorySummaryDto;
+import com.example.nocap.domain.history.entity.History;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface HistoryMapper {
+
+    History toHistory(HistoryRequestDto historyRequestDto);
+
+    HistorySummaryDto toHistorySummary(History history);
+
+    HistoryDetailDto toHistoryDetailDto(History history);
+
+}

--- a/src/main/java/com/example/nocap/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/com/example/nocap/domain/history/repository/HistoryRepository.java
@@ -1,0 +1,18 @@
+package com.example.nocap.domain.history.repository;
+
+import com.example.nocap.domain.history.entity.History;
+import com.example.nocap.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HistoryRepository extends JpaRepository<History, Long> {
+
+    List<History> findAllByUser(User user);
+
+    // 특정 사용자의 히스토리 개수를 세는 메소드
+    long countByUser(User user);
+
+    // 특정 사용자의 히스토리 중 createdAt을 기준으로 오름차순 정렬하여 첫 번째 것을 찾는 메소드
+    Optional<History> findFirstByUserOrderByCreatedAtAsc(User user);
+}

--- a/src/main/java/com/example/nocap/domain/history/service/HistoryService.java
+++ b/src/main/java/com/example/nocap/domain/history/service/HistoryService.java
@@ -1,0 +1,79 @@
+package com.example.nocap.domain.history.service;
+
+import com.example.nocap.auth.dto.response.UserDetail;
+import com.example.nocap.domain.history.dto.HistoryDetailDto;
+import com.example.nocap.domain.history.dto.HistoryRequestDto;
+import com.example.nocap.domain.history.dto.HistorySummaryDto;
+import com.example.nocap.domain.history.entity.History;
+import com.example.nocap.domain.history.mapper.HistoryMapper;
+import com.example.nocap.domain.history.repository.HistoryRepository;
+import com.example.nocap.domain.user.entity.User;
+import com.example.nocap.domain.user.repository.UserRepository;
+import com.example.nocap.exception.CustomException;
+import com.example.nocap.exception.ErrorCode;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final UserRepository userRepository;
+    private final HistoryRepository historyRepository;
+    private final HistoryMapper historyMapper;
+
+    private static final int MAX_HISTORY_COUNT = 10; // 최대 히스토리 개수 상수로 관리
+
+
+    @Transactional
+    public HistoryRequestDto saveHistory(HistoryRequestDto historyRequestDto, UserDetail userDetail) {
+
+        Long id = userDetail.getId();
+        User user = userRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        History history = historyMapper.toHistory(historyRequestDto);
+        history.setUser(user);
+        historyRepository.save(history);
+
+        // 해당 사용자의 히스토리 총 개수 확인
+        long historyCount = historyRepository.countByUser(user);
+
+        // 히스토리 개수가 최대 개수를 초과하면
+        if (historyCount > MAX_HISTORY_COUNT) {
+            // 가장 오래된 히스토리 1개를 찾아서
+            // 5. 삭제
+            historyRepository.findFirstByUserOrderByCreatedAtAsc(user)
+                .ifPresent(historyRepository::delete);
+        }
+
+        return historyRequestDto;
+    }
+
+    public List<HistorySummaryDto> getAllHistory(UserDetail userDetail) {
+        Long id = userDetail.getId();
+        User user = userRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        List<History> historyList = historyRepository.findAllByUser(user);
+        return historyList.stream()
+            .map(historyMapper::toHistorySummary)
+            .toList();
+    }
+
+    public HistoryDetailDto getHistory(Long historyId, UserDetail userDetail) {
+        Long id = userDetail.getId();
+        User user = userRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        History history = historyRepository.findById(historyId)
+            .orElseThrow(() -> new CustomException(ErrorCode.HISTORY_NOT_FOUND));
+
+        if (!Objects.equals(history.getUser().getId(), id)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        return historyMapper.toHistoryDetailDto(history);
+    }
+}

--- a/src/main/java/com/example/nocap/exception/ErrorCode.java
+++ b/src/main/java/com/example/nocap/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기사를 찾을 수 없습니다."),
     ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "분석을 찾을 수 없습니다."),
+    HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "검색기록을 찾을 수 없습니다."),
 
     // 409 Conflict: 충돌
     DUPLICATE_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),


### PR DESCRIPTION
### 반영 브랜치
feat/history -> develop

### 변경사항
- 뉴스의 전체 정보(url, title, content, image, date)로 조회 기록 기능 추가
- 뉴스 조회 기록에 대해 SummaryDto와 DetailDto로 조회 Dto를 구분하여 전체와 각각 조회 구현
- 저장 시 10개가 넘어가면 큐 형식으로 삭제

### 테스트 결과
<img width="2018" height="1014" alt="image" src="https://github.com/user-attachments/assets/3efcded7-a4fc-4d0d-83b2-11f9c9af837d" />
