### PR TITLE
Refactor/pop news

### DIFF
--- a/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/nocap/auth/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
         "/api/nocap/analysis/keyword/{keyword}", // 키워드별 분석 조회
         "/api/nocap/analysis/category/{category}", // 카테고리별 분석 조회
         "/api/nocap/search/**",              // 뉴스 검색 관련 모든 경로 (category, keyword 포함)
-        "/api/nocap/popnews",                // 인기 뉴스
+        "/api/nocap/popnews",                // 인기 뉴스 전체 조회
+        "/api/nocap/popnews/**",             // 인기 뉴스
 
         // Swagger 문서
         "/swagger-ui/**",

--- a/src/main/java/com/example/nocap/domain/popnews/controller/PopNewsController.java
+++ b/src/main/java/com/example/nocap/domain/popnews/controller/PopNewsController.java
@@ -1,13 +1,17 @@
 package com.example.nocap.domain.popnews.controller;
 
+import com.example.nocap.domain.popnews.dto.PopNewsDetailDto;
 import com.example.nocap.domain.popnews.dto.PopNewsDto;
+import com.example.nocap.domain.popnews.dto.PopNewsSummaryDto;
 import com.example.nocap.domain.popnews.service.PopNewsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.method.P;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,13 +23,23 @@ public class PopNewsController {
     private final PopNewsService popNewsService;
 
     @Operation(
-        summary = "인기뉴스 조회",
+        summary = "인기뉴스 전체 조회",
         description = "하루 주기로 갱신되는 인기뉴스 조회",
         responses = { /* ... */ }
     )
     @GetMapping
-    public ResponseEntity<List<PopNewsDto>> getPopNews() {
-        return ResponseEntity.ok(popNewsService.getPopNews());
+    public ResponseEntity<List<PopNewsSummaryDto>> getAllPopNews() {
+        return ResponseEntity.ok(popNewsService.getAllPopNews());
+    }
+
+    @Operation(
+        summary = "특정 인기뉴스 조회",
+        description = "popNewsId를 통해 특정 인기뉴스 조회",
+        responses = { /* ... */ }
+    )
+    @GetMapping("/{popNewsId}")
+    public ResponseEntity<PopNewsDetailDto> getPopNews(@PathVariable("popNewsId") Long popNewsId) {
+        return ResponseEntity.ok(popNewsService.getPopNews(popNewsId));
     }
 
 }

--- a/src/main/java/com/example/nocap/domain/popnews/dto/PopNewsDetailDto.java
+++ b/src/main/java/com/example/nocap/domain/popnews/dto/PopNewsDetailDto.java
@@ -1,0 +1,19 @@
+package com.example.nocap.domain.popnews.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PopNewsDetailDto {
+
+    private String url;
+
+    private String title;
+
+    private String content;
+
+    private String image;
+    private String date;
+
+}

--- a/src/main/java/com/example/nocap/domain/popnews/dto/PopNewsSummaryDto.java
+++ b/src/main/java/com/example/nocap/domain/popnews/dto/PopNewsSummaryDto.java
@@ -1,0 +1,19 @@
+package com.example.nocap.domain.popnews.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PopNewsSummaryDto {
+
+    private Long popNewsId;
+
+    private String url;
+
+    private String title;
+
+    private String image;
+    private String date;
+
+}

--- a/src/main/java/com/example/nocap/domain/popnews/mapper/PopNewsMapper.java
+++ b/src/main/java/com/example/nocap/domain/popnews/mapper/PopNewsMapper.java
@@ -2,7 +2,9 @@ package com.example.nocap.domain.popnews.mapper;
 
 import com.example.nocap.domain.mainnews.mapper.MainNewsMapper;
 import com.example.nocap.domain.news.mapper.NewsMapper;
+import com.example.nocap.domain.popnews.dto.PopNewsDetailDto;
 import com.example.nocap.domain.popnews.dto.PopNewsDto;
+import com.example.nocap.domain.popnews.dto.PopNewsSummaryDto;
 import com.example.nocap.domain.popnews.entity.PopNews;
 import java.util.List;
 import org.mapstruct.Mapper;
@@ -12,6 +14,12 @@ import org.mapstruct.Mapper;
 public interface PopNewsMapper {
 
     PopNewsDto toPopNewsDto(PopNews popNews);
+
+    PopNewsDetailDto toPopNewsDetailDto(PopNews popNews);
+    PopNewsSummaryDto toPopNewsSummaryDto(PopNews popNews);
+
+    List<PopNewsDetailDto> toPopNewsDetailDtoList(List<PopNews> popNewsList);
+    List<PopNewsSummaryDto> toPopNewsSummaryDtoList(List<PopNews> popNewsList);
 
     List<PopNewsDto> toPopNewsDtoList(List<PopNews> popNewsList);
 

--- a/src/main/java/com/example/nocap/domain/popnews/service/PopNewsService.java
+++ b/src/main/java/com/example/nocap/domain/popnews/service/PopNewsService.java
@@ -1,7 +1,9 @@
 package com.example.nocap.domain.popnews.service;
 
 import com.example.nocap.domain.analysis.service.ArticleExtractionService;
+import com.example.nocap.domain.popnews.dto.PopNewsDetailDto;
 import com.example.nocap.domain.popnews.dto.PopNewsDto;
+import com.example.nocap.domain.popnews.dto.PopNewsSummaryDto;
 import com.example.nocap.domain.popnews.entity.PopNews;
 import com.example.nocap.domain.popnews.mapper.PopNewsMapper;
 import com.example.nocap.domain.popnews.repository.PopNewsRepository;
@@ -106,7 +108,13 @@ public class PopNewsService {
         }
     }
 
-    public List<PopNewsDto> getPopNews() {
-        return popNewsMapper.toPopNewsDtoList(popNewsRepository.findAll());
+    public List<PopNewsSummaryDto> getAllPopNews() {
+        return popNewsMapper.toPopNewsSummaryDtoList(popNewsRepository.findAll());
+    }
+
+    public PopNewsDetailDto getPopNews(Long popNewsId) {
+        PopNews popNews = popNewsRepository.findById(popNewsId)
+            .orElseThrow(() -> new CustomException(ErrorCode.POP_NEWS_NOT_FOUND));
+        return popNewsMapper.toPopNewsDetailDto(popNews);
     }
 }

--- a/src/main/java/com/example/nocap/exception/ErrorCode.java
+++ b/src/main/java/com/example/nocap/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기사를 찾을 수 없습니다."),
     ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "분석을 찾을 수 없습니다."),
+    POP_NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "인기뉴스를 찾을 수 없습니다."),
 
     // 409 Conflict: 충돌
     DUPLICATE_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),


### PR DESCRIPTION
### 반영 브랜치
refactor/pop-news -> develop

### 변경사항
- 인기뉴스에 대해 전체 조회와 개별 조회로 Dto 및 API 구분

### 테스트 결과
<img width="2026" height="828" alt="image" src="https://github.com/user-attachments/assets/53d23818-935b-4164-aee3-7e016ab3fd47" />
