### PR TITLE
Refactor/crawling-by-category

### DIFF
--- a/src/main/java/com/example/nocap/domain/searchnews/controller/SearchNewsController.java
+++ b/src/main/java/com/example/nocap/domain/searchnews/controller/SearchNewsController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "SearchNews", description = "뉴스 검색 API") // ✨ 1. @Tag 어노테이션 이동
+@Tag(name = "SearchNews", description = "뉴스 검색 API") //
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/nocap/search")


### PR DESCRIPTION
### 반영 브랜치
refactor/crawling-by-category -> develop

### 변경사항
- 카테고리별 뉴스 조회 결과에서 url을 원본 url로 수정
- content가 html 태그를 가지도록 수정


### 테스트 결과
<img width="2020" height="952" alt="image" src="https://github.com/user-attachments/assets/57a2a872-f97a-496b-9a0a-1dbe72873dd5" />