### PR TITLE
Refactor/news content

### DIFF
--- a/src/main/java/com/example/nocap/domain/analysis/mapper/AnalysisMapper.java
+++ b/src/main/java/com/example/nocap/domain/analysis/mapper/AnalysisMapper.java
@@ -5,31 +5,28 @@ import com.example.nocap.domain.analysis.dto.AnalysisViewDto;
 import com.example.nocap.domain.analysis.dto.SbertResponseDto;
 import com.example.nocap.domain.analysis.entity.Analysis;
 import com.example.nocap.domain.mainnews.mapper.MainNewsMapper;
-import com.example.nocap.domain.news.entity.News;
 import com.example.nocap.domain.news.mapper.NewsMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring", uses = {MainNewsMapper.class, NewsMapper.class})
 public interface AnalysisMapper {
 
-    AnalysisMapper INSTANCE = Mappers.getMapper(AnalysisMapper.class);
-
-    @Mapping(source = "mainNews.image", target = "image")
-    @Mapping(source = "mainNews.title", target = "mainNewsTitle")
+    // Analysis -> AnalysisDto
+    @Mapping(source = "analysis.mainNews.image", target = "image")
+    @Mapping(source = "analysis.mainNews.title", target = "mainNewsTitle")
     AnalysisDto toAnalysisDto(Analysis analysis);
 
-    @Mapping(source = "mainNews.title", target = "mainNewsTitle")
-    @Mapping(source = "mainNews.image", target = "image")
-    // 2. 객체 자체를 DTO로 매핑 (MainNewsMapper 사용)
-    @Mapping(source = "mainNews", target = "mainNewsDto")
-    // 3. 자식 리스트를 DTO 리스트로 매핑 (NewsMapper 사용)
-    @Mapping(source = "relatedNews", target = "newsComparisonDtos", qualifiedByName = "Sbert")
-    @Mapping(source = "isBookmarked", target = "isBookmarked")
+    // Analysis -> AnalysisViewDto
+    @Mapping(source = "analysis.mainNews.title", target = "mainNewsTitle")
+    @Mapping(source = "analysis.mainNews.image", target = "image")
+    @Mapping(source = "analysis.mainNews", target = "mainNewsDto")
+    @Mapping(source = "analysis.relatedNews", target = "newsComparisonDtos", qualifiedByName = "Sbert")
+    @Mapping(source = "isBookmarked", target = "bookmarked")
     AnalysisViewDto toAnalysisViewDto(Analysis analysis, boolean isBookmarked);
 
-    @Mapping(source = "mainNews", target = "mainNewsDto")
-    @Mapping(source = "relatedNews", target = "newsComparisonDtos", qualifiedByName = "Sbert")
+    // Analysis -> SbertResponseDto
+    @Mapping(source = "analysis.mainNews", target = "mainNewsDto")
+    @Mapping(source = "analysis.relatedNews", target = "newsComparisonDtos", qualifiedByName = "Sbert")
     SbertResponseDto toSbertResponseDto(Analysis analysis);
 }

--- a/src/main/java/com/example/nocap/domain/analysis/service/ArticleExtractionService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/ArticleExtractionService.java
@@ -1,196 +1,46 @@
 package com.example.nocap.domain.analysis.service;
 
+import com.example.nocap.domain.analysis.service.parser.SiteSpecificParser;
 import com.example.nocap.domain.mainnews.entity.MainNews;
 import com.example.nocap.exception.CustomException;
 import com.example.nocap.exception.ErrorCode;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-import net.dankito.readability4j.Article;
-import net.dankito.readability4j.Readability4J;
+import lombok.RequiredArgsConstructor;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+
 @Service
+@RequiredArgsConstructor
+@Slf4j
+
 public class ArticleExtractionService {
 
+    private final List<SiteSpecificParser> parsers;
+
     public MainNews extract(String url) {
+        log.info("Article Extraction Eroc ess for URL: {}", url);
         try {
-            Document doc = Jsoup.connect(url).get();
-            if (!isArticleByConfidenceScore(doc)) {
-                throw new CustomException(ErrorCode.NOT_A_NEWS_ARTICLE);
+            Document doc = Jsoup.connect(url)
+                .userAgent("Mozilla/5.0")
+                .timeout(5000)
+                .get();
+
+            // URL에 맞는 전문 파서를 찾아서 실행
+            for (SiteSpecificParser parser : parsers) {
+                if (parser.canParse(url)) {
+                    return parser.extract(doc, url);
+                }
             }
 
-            preprocessDocument(doc);
-
-            String ogTitle = getMetaTagContent(doc, "og:title");
-            String ogImage = getMetaTagContent(doc, "og:image");
-
-            Article article = new Readability4J(url, doc.html()).parse();
-            String htmlContent = article.getContent();
-
-            String finalTitle = (!ogTitle.isEmpty()) ? ogTitle : article.getTitle();
-            finalTitle = unescape(finalTitle);
-
-            String pubDateString = extractPublishedDate(doc);
-            String pubDate = parseDateString(pubDateString); // String -> LocalDateTime 변환
-
-            String canonicalUrl = createCanonicalUrl(doc, url); // 정규화 로직 적용
-
-            if (htmlContent == null || htmlContent.trim().isEmpty()) {
-                throw new CustomException(ErrorCode.EXTERNAL_API_ERROR);
-            }
-
-            return MainNews.builder()
-                .url(url)
-                .canonicalUrl(canonicalUrl)
-                .title(finalTitle)
-                .content(htmlContent)
-                .image(ogImage)
-                .date(pubDate)
-                .build();
+            throw new CustomException(ErrorCode.NEWS_EXTRACTING_ERROR);
 
         } catch (IOException e) {
             throw new CustomException(ErrorCode.EXTERNAL_API_ERROR);
-        }
-    }
-
-    private String createCanonicalUrl(Document doc, String originalUrl) {
-        // 1순위: og:url
-        String ogUrl = getMetaTagContent(doc, "og:url");
-        if (!ogUrl.isEmpty()) {
-            return ogUrl;
-        }
-        // 2순위: link[rel=canonical]
-        Element canonicalLink = doc.selectFirst("link[rel=canonical]");
-        if (canonicalLink != null && canonicalLink.hasAttr("href")) {
-            return canonicalLink.attr("href");
-        }
-        // 3순위: normalizeUrl
-        return normalizeUrl(originalUrl);
-    }
-
-    private void preprocessDocument(Document doc) {
-        doc.select(".read_cont, em.img_desc, span.img_desc, .desc_thumb").remove();
-    }
-
-    private String unescape(String text) {
-        if (text == null) return null;
-        return text.replace("\\\"", "\"").replace("\\'", "'");
-    }
-
-    private String getMetaTagContent(Document doc, String property) {
-        Element metaTag = doc.selectFirst("meta[property=" + property + "]");
-        return (metaTag != null) ? metaTag.attr("content") : "";
-    }
-
-    private String extractPublishedDate(Document doc) {
-        // 우선순위대로 날짜를 포함할 가능성이 높은 선택자 목록
-        String[] dateSelectors = {
-            "meta[property=article:published_time]", // 1순위: 국제 표준 메타 태그
-            "span.num_date",
-            "span._ARTICLE_DATE_TIME",              // 2순위: 네이버 뉴스
-            "span.t11",                             // 3순위: 네이버 뉴스 (구버전)
-            "span[class*='date']",                  // 4순위: 'date' 클래스를 포함하는 span
-            "time"                                  // 5순위: <time> 태그
-        };
-
-        for (String selector : dateSelectors) {
-            Element dateElement = doc.selectFirst(selector);
-            if (dateElement != null) {
-                if (dateElement.hasAttr("content")) return dateElement.attr("content");
-                if (dateElement.hasAttr("data-date-time")) return dateElement.attr("data-date-time");
-                return dateElement.text();
-            }
-        }
-        return null; // 날짜를 찾지 못한 경우
-    }
-
-    private String parseDateString(String dateString) {
-        if (dateString == null || dateString.isBlank()) {
-            return null;
-        }
-
-        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd"); // 최종 출력 형식
-
-        List<DateTimeFormatter> formatters = List.of(
-            DateTimeFormatter.ISO_OFFSET_DATE_TIME,
-            DateTimeFormatter.RFC_1123_DATE_TIME,
-            DateTimeFormatter.ofPattern("yyyy. M. d. HH:mm"),
-            DateTimeFormatter.ofPattern("yyyy.MM.dd. a H:mm"),
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-        );
-
-        for (DateTimeFormatter formatter : formatters) {
-            try {
-                // 시간대 정보가 포함된 형식(RFC, ISO)은 ZonedDateTime으로 파싱
-                return ZonedDateTime.parse(dateString, formatter).format(outputFormatter);
-            } catch (java.time.format.DateTimeParseException e1) {
-                try {
-                    // 시간대 정보가 없는 형식은 LocalDateTime으로 파싱
-                    return LocalDateTime.parse(dateString, formatter).format(outputFormatter);
-                } catch (java.time.format.DateTimeParseException e2) {
-                    // 둘 다 실패하면 다음 포맷터로 계속
-                }
-            }
-        }
-
-        // 정규식으로 'YYYY-MM-DD' 또는 'YYYY.MM.DD' 형태만 추출 시도
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("\\d{4}[-.]\\d{2}[-.]\\d{2}");
-        java.util.regex.Matcher matcher = pattern.matcher(dateString);
-        if (matcher.find()) {
-            return matcher.group(0).replace(".", "-");
-        }
-
-        return null; // 모든 형식에 실패하면 null 반환
-    }
-
-    private boolean isArticleByConfidenceScore(Document doc) {
-        int confidenceScore = 0;
-        final int THRESHOLD = 4;
-
-        Element ogTypeElement = doc.selectFirst("meta[property=og:type]");
-        if (ogTypeElement != null && "article".equalsIgnoreCase(ogTypeElement.attr("content"))) {
-            confidenceScore += 5;
-        }
-        if (doc.selectFirst("article") != null) {
-            confidenceScore += 3;
-        }
-        if (doc.selectFirst("div[class*='article'], div[class*='content'], div[id*='article'], div[id*='content']") != null) {
-            confidenceScore += 2;
-        }
-        if (doc.selectFirst("h1") != null) {
-            confidenceScore += 1;
-        }
-
-        return confidenceScore >= THRESHOLD;
-    }
-
-    private String normalizeUrl(String urlString) {
-        try {
-            URL url = new URL(urlString);
-            String path = url.getPath();
-            String query = url.getQuery();
-            if (query == null || query.isEmpty()) {
-                return url.getProtocol() + "://" + url.getHost() + path;
-            }
-            List<String> essentialParams = List.of("article_id", "id", "no", "idx", "pno", "newsid");
-            String preservedQuery = Arrays.stream(query.split("&"))
-                .filter(param -> essentialParams.stream().anyMatch(key -> param.startsWith(key + "=")))
-                .sorted()
-                .collect(Collectors.joining("&"));
-            String baseUrl = url.getProtocol() + "://" + url.getHost() + path;
-            return preservedQuery.isEmpty() ? baseUrl : baseUrl + "?" + preservedQuery;
-        } catch (MalformedURLException e) {
-            return urlString;
         }
     }
 }

--- a/src/main/java/com/example/nocap/domain/analysis/service/NaverNewsService.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/NaverNewsService.java
@@ -132,7 +132,7 @@ public class NaverNewsService {
             item.getTitle().equals(excludeTitle) || item.getOriginallink().equals(excludeUrl)
         );
 
-        // 3. 중복 제거된 게 없고, 11개 이상일 때 마지막 하나만 제거
+        // 3. 중복 제거된 게 없고, 6개 이상일 때 마지막 하나만 제거
         if (!removed && items.size() > 5) {
             items.remove(items.size() - 1);
         }

--- a/src/main/java/com/example/nocap/domain/analysis/service/parser/ChosunBizParser.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/parser/ChosunBizParser.java
@@ -1,0 +1,130 @@
+package com.example.nocap.domain.analysis.service.parser;
+
+import com.example.nocap.domain.mainnews.entity.MainNews;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Order(1)
+@Slf4j
+public class ChosunBizParser implements SiteSpecificParser {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public boolean canParse(String url) {
+        return url.contains("biz.chosun.com");
+    }
+
+    @Override
+    public MainNews extract(Document doc, String url) {
+        log.info(">>>>> Executing ChosunBizParser for: {}", url);
+
+        try {
+            // 1. <script id="fusion-metadata"> 태그 찾기
+            Element scriptElement = doc.selectFirst("script#fusion-metadata");
+            if (scriptElement == null) {
+                log.warn("ChosunBizParser [FAIL]: Fusion metadata script tag ('script#fusion-metadata') not found.");
+                return null;
+            }
+            log.info("ChosunBizParser [SUCCESS]: Found fusion metadata script tag.");
+
+            // 2. 스크립트 내용에서 JSON 부분만 추출
+            String scriptData = scriptElement.html();
+            int jsonStart = scriptData.indexOf("Fusion.globalContent=");
+            if (jsonStart == -1) {
+                log.warn("ChosunBizParser [FAIL]: 'Fusion.globalContent=' string not found in script.");
+                return null;
+            }
+            // 시작 위치 조정
+            jsonStart += "Fusion.globalContent=".length();
+            // 끝 위치 찾기
+            int jsonEnd = scriptData.indexOf("};", jsonStart);
+            if (jsonEnd == -1) {
+                log.warn("ChosunBizParser [FAIL]: Could not find end of JSON object ('}};').");
+                return null;
+            }
+
+            String jsonString = scriptData.substring(jsonStart, jsonEnd + 1);
+            JsonNode globalContent = objectMapper.readTree(jsonString);
+
+            // 3. JSON에서 정보 추출
+            String title = globalContent.path("headlines").path("basic").asText("제목 없음");
+            String dateString = globalContent.path("created_date").asText(null);
+            String imageUrl = getMetaTagContent(doc, "og:image");
+
+            log.info(">>>>> JSON Title: {}", title);
+            log.info(">>>>> JSON Date: {}", dateString);
+
+            // 4. content_elements 배열에서 type이 'text'인 것들의 content만 합치기
+            List<String> contentParts = new ArrayList<>();
+            JsonNode contentElements = globalContent.path("content_elements");
+            if (contentElements.isArray()) {
+                for (JsonNode element : contentElements) {
+                    if ("text".equals(element.path("type").asText())) {
+                        contentParts.add(element.path("content").asText());
+                    }
+                }
+            }
+            String contentWithTags = contentParts.stream()
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.joining(" "));
+
+            String plainContent = Jsoup.parse(contentWithTags).text();
+
+            log.info(">>>>> Content Parts Found: {}, Total Length: {}", contentParts.size(), plainContent.length());
+
+            if (plainContent.isBlank()) {
+                log.warn("ChosunBizParser: 본문 내용을 추출하지 못했습니다. URL: {}", url);
+                return null;
+            }
+            log.info(">>>>> JSON Content: {}", plainContent);
+            return MainNews.builder()
+                .url(url)
+                .canonicalUrl(url)
+                .title(unescape(title))
+                .content(plainContent)
+                .image(imageUrl)
+                .date(parseDateString(dateString))
+                .build();
+
+        } catch (Exception e) {
+            log.error("ChosunBizParser failed to parse JSON metadata", e);
+            return null;
+        }
+    }
+
+    // --- 헬퍼 메소드들 ---
+    private String getMetaTagContent(Document doc, String property) {
+        Element metaTag = doc.selectFirst("meta[property=" + property + "]");
+        return (metaTag != null) ? metaTag.attr("content") : "";
+    }
+
+    private String unescape(String text) {
+        if (text == null) return null;
+        return text.replace("\\\"", "\"").replace("\\'", "'");
+    }
+
+    private String parseDateString(String dateString) {
+        if (dateString == null || dateString.isBlank()) return null;
+        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        try {
+            return ZonedDateTime.parse(dateString, DateTimeFormatter.ISO_ZONED_DATE_TIME).format(outputFormatter);
+        } catch (Exception e) {
+            log.warn("ChosunBizParser: 날짜 파싱 실패 - {}", dateString);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/nocap/domain/analysis/service/parser/ChosunParser.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/parser/ChosunParser.java
@@ -1,0 +1,132 @@
+package com.example.nocap.domain.analysis.service.parser;
+
+import com.example.nocap.domain.mainnews.entity.MainNews;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Order(2) // 다른 전문 파서들과 실행 순서를 정하기 위함
+@Slf4j
+public class ChosunParser implements SiteSpecificParser {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public boolean canParse(String url) {
+        // biz.chosun.com이 아닌 chosun.com을 처리하도록 수정
+        return url.contains("www.chosun.com") && !url.contains("biz.chosun.com");
+    }
+
+    @Override
+    public MainNews extract(Document doc, String url) {
+        log.info(">>>>> Executing ChosunParser for: {}", url);
+
+        try {
+            // 1. <script id="fusion-metadata"> 태그 찾기
+            Element scriptElement = doc.selectFirst("script#fusion-metadata");
+            if (scriptElement == null) {
+                log.warn("ChosunParser [FAIL]: Fusion metadata script tag ('script#fusion-metadata') not found.");
+                return null;
+            }
+
+            // 2. 스크립트 내용에서 JSON 부분만 추출
+            String scriptData = scriptElement.html();
+            int jsonStart = scriptData.indexOf("Fusion.globalContent=");
+            if (jsonStart == -1) {
+                log.warn("ChosunParser [FAIL]: 'Fusion.globalContent=' string not found in script.");
+                return null;
+            }
+            jsonStart += "Fusion.globalContent=".length();
+            int jsonEnd = scriptData.indexOf("};", jsonStart);
+            if (jsonEnd == -1) {
+                log.warn("ChosunParser [FAIL]: Could not find end of JSON object ('}};').");
+                return null;
+            }
+
+            String jsonString = scriptData.substring(jsonStart, jsonEnd + 1);
+            JsonNode globalContent = objectMapper.readTree(jsonString);
+
+            // 3. JSON에서 정보 추출
+            String title = globalContent.path("headlines").path("basic").asText("제목 없음");
+            String dateString = globalContent.path("created_date").asText(null);
+            String imageUrl = getMetaTagContent(doc, "og:image");
+
+            log.info(">>>>> JSON Title: {}", title);
+            log.info(">>>>> JSON Date: {}", dateString);
+
+            // 4. content_elements 배열에서 type이 'text' 또는 'raw_html'인 것들의 content만 합치기
+            List<String> contentParts = new ArrayList<>();
+            JsonNode contentElements = globalContent.path("content_elements");
+            if (contentElements.isArray()) {
+                for (JsonNode element : contentElements) {
+                    String type = element.path("type").asText();
+                    if ("text".equals(type) || "raw_html".equals(type)) {
+                        String content = element.path("content").asText();
+                        // raw_html의 경우, 내부의 HTML 태그를 제거
+                        if ("raw_html".equals(type)) {
+                            content = Jsoup.parse(content).text();
+                        }
+                        contentParts.add(content);
+                    }
+                }
+            }
+            String plainContent = contentParts.stream()
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.joining(" "));
+
+            if (plainContent.isBlank()) {
+                log.warn("ChosunParser: 본문 내용을 추출하지 못했습니다. URL: {}", url);
+                return null;
+            }
+
+            log.info(">>>>> JSON Content: {}", plainContent);
+
+            return MainNews.builder()
+                .url(url)
+                .canonicalUrl(getMetaTagContent(doc, "og:url"))
+                .title(unescape(title))
+                .content(plainContent)
+                .image(imageUrl)
+                .date(parseDateString(dateString))
+                .build();
+
+        } catch (Exception e) {
+            log.error("ChosunParser failed to parse JSON metadata", e);
+            return null;
+        }
+    }
+
+    // --- 헬퍼 메소드들 ---
+    private String getMetaTagContent(Document doc, String property) {
+        Element metaTag = doc.selectFirst("meta[property=" + property + "]");
+        return (metaTag != null) ? metaTag.attr("content") : "";
+    }
+
+    private String unescape(String text) {
+        if (text == null) return null;
+        return text.replace("\\\"", "\"").replace("\\'", "'");
+    }
+
+    private String parseDateString(String dateString) {
+        if (dateString == null || dateString.isBlank()) return null;
+        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        try {
+            return ZonedDateTime.parse(dateString, DateTimeFormatter.ISO_ZONED_DATE_TIME).format(outputFormatter);
+        } catch (Exception e) {
+            log.warn("ChosunParser: 날짜 파싱 실패 - {}", dateString);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/nocap/domain/analysis/service/parser/GenericNewsParser.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/parser/GenericNewsParser.java
@@ -1,0 +1,218 @@
+package com.example.nocap.domain.analysis.service.parser;
+
+import com.example.nocap.domain.mainnews.entity.MainNews;
+import com.example.nocap.exception.CustomException;
+import com.example.nocap.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import net.dankito.readability4j.Article;
+import net.dankito.readability4j.Readability4J;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Component
+@Order(Integer.MAX_VALUE) // 가장 마지막에 실행되도록 우선순위를 낮게 설정
+@Slf4j // @Slf4j 추가
+public class GenericNewsParser implements SiteSpecificParser {
+
+    @Override
+    public boolean canParse(String url) {
+        // 모든 URL을 처리할 수 있는 최종 Fallback 파서이므로 항상 true를 반환
+        return true;
+    }
+
+    @Override
+    public MainNews extract(Document doc, String url) {
+        log.info("   >>>>> Executing GenericNewsParser for: {}", url);
+
+        if (!isArticleByConfidenceScore(doc)) {
+            throw new CustomException(ErrorCode.NOT_A_NEWS_ARTICLE);
+        }
+
+        preprocessDocument(doc);
+
+        String ogTitle = getMetaTagContent(doc, "og:title");
+        String ogImage = getMetaTagContent(doc, "og:image");
+
+        Article article = new Readability4J(url, doc.html()).parse();
+        String rawContent = article.getTextContent();
+
+        String finalTitle = (!ogTitle.isEmpty()) ? ogTitle : article.getTitle();
+        finalTitle = unescape(finalTitle);
+        log.info(">>>>> JSON Title: {}", finalTitle);
+
+        String cleanedContent = postProcessContent(rawContent, finalTitle);
+
+        String pubDateString = extractPublishedDate(doc);
+        String pubDate = parseDateString(pubDateString);
+        log.info(">>>>> JSON Date: {}", pubDate);
+
+        String canonicalUrl = createCanonicalUrl(doc, url);
+
+        if (cleanedContent == null || cleanedContent.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.NEWS_EXTRACTING_ERROR);
+        }
+
+        log.info(">>>>> JSON Content: {}", cleanedContent);
+
+
+        return MainNews.builder()
+            .url(url)
+            .canonicalUrl(canonicalUrl)
+            .title(finalTitle)
+            .content(cleanedContent)
+            .image(ogImage)
+            .date(pubDate)
+            .build();
+    }
+    private String postProcessContent(String text, String title) {
+        if (text == null || text.isBlank()) {
+            return "";
+        }
+        String processedText = text;
+
+        processedText = processedText.replace("\\\"", "\"").replace("\\'", "'");
+        processedText = processedText.replace("\\", "");
+
+        if (title != null && !title.isBlank()) {
+            // 비교를 위해 양쪽에서 모든 따옴표(작은/큰)를 제거
+            String normalizedTitle = title.replace("'", "").replace("\"", "");
+            String normalizedContent = processedText.replace("'", "").replace("\"", "");
+
+            if (normalizedContent.startsWith(normalizedTitle)) {
+                processedText = processedText.substring(title.length()).trim();
+            }
+        }
+
+        processedText = processedText.replaceAll("^(입력|수정).*?기자", "").trim();
+
+        processedText = processedText.replaceAll("< 저작권자 ⓒ .*?>", "").trim();
+        processedText = processedText.replaceAll("※ 본 사이트에 게재되는 정보는.*", "").trim();
+
+        processedText = processedText.replaceAll("\\s+", " ").trim();
+
+        return processedText;
+    }
+
+    private String createCanonicalUrl(Document doc, String originalUrl) {
+        String ogUrl = getMetaTagContent(doc, "og:url");
+        if (!ogUrl.isEmpty()) {
+            return ogUrl;
+        }
+        Element canonicalLink = doc.selectFirst("link[rel=canonical]");
+        if (canonicalLink != null && canonicalLink.hasAttr("href")) {
+            return canonicalLink.attr("href");
+        }
+        return normalizeUrl(originalUrl);
+    }
+
+    private void preprocessDocument(Document doc) {
+        doc.select(".read_cont, em.img_desc, span.img_desc, .desc_thumb").remove();
+    }
+
+    private String unescape(String text) {
+        if (text == null) return null;
+        return text.replace("\\\"", "\"").replace("\\'", "'");
+    }
+
+    private String getMetaTagContent(Document doc, String property) {
+        Element metaTag = doc.selectFirst("meta[property=" + property + "]");
+        return (metaTag != null) ? metaTag.attr("content") : "";
+    }
+
+    private String extractPublishedDate(Document doc) {
+        String[] dateSelectors = {
+            "meta[property=article:published_time]", "span.num_date",
+            "span._ARTICLE_DATE_TIME", "span.t11", "span[class*='date']", "time"
+        };
+        for (String selector : dateSelectors) {
+            Element dateElement = doc.selectFirst(selector);
+            if (dateElement != null) {
+                if (dateElement.hasAttr("content")) return dateElement.attr("content");
+                if (dateElement.hasAttr("data-date-time")) return dateElement.attr("data-date-time");
+                return dateElement.text();
+            }
+        }
+        return null;
+    }
+
+    private String parseDateString(String dateString) {
+        if (dateString == null || dateString.isBlank()) {
+            return null;
+        }
+        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        List<DateTimeFormatter> formatters = List.of(
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME, DateTimeFormatter.RFC_1123_DATE_TIME,
+            DateTimeFormatter.ofPattern("yyyy. M. d. HH:mm"),
+            DateTimeFormatter.ofPattern("yyyy.MM.dd. a H:mm"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        );
+        for (DateTimeFormatter formatter : formatters) {
+            try {
+                return ZonedDateTime.parse(dateString, formatter).format(outputFormatter);
+            } catch (java.time.format.DateTimeParseException e1) {
+                try {
+                    return LocalDateTime.parse(dateString, formatter).format(outputFormatter);
+                } catch (java.time.format.DateTimeParseException e2) {
+                    // 다음 포맷터로 계속
+                }
+            }
+        }
+        Pattern pattern = Pattern.compile("\\d{4}[-.]\\d{2}[-.]\\d{2}");
+        java.util.regex.Matcher matcher = pattern.matcher(dateString);
+        if (matcher.find()) {
+            return matcher.group(0).replace(".", "-");
+        }
+        return null;
+    }
+
+    private boolean isArticleByConfidenceScore(Document doc) {
+        int confidenceScore = 0;
+        final int THRESHOLD = 4;
+        Element ogTypeElement = doc.selectFirst("meta[property=og:type]");
+        if (ogTypeElement != null && "article".equalsIgnoreCase(ogTypeElement.attr("content"))) {
+            confidenceScore += 5;
+        }
+        if (doc.selectFirst("article") != null) {
+            confidenceScore += 3;
+        }
+        if (doc.selectFirst("div[class*='article'], div[class*='content'], div[id*='article'], div[id*='content']") != null) {
+            confidenceScore += 2;
+        }
+        if (doc.selectFirst("h1") != null) {
+            confidenceScore += 1;
+        }
+        return confidenceScore >= THRESHOLD;
+    }
+
+    private String normalizeUrl(String urlString) {
+        try {
+            URL url = new URL(urlString);
+            String path = url.getPath();
+            String query = url.getQuery();
+            if (query == null || query.isEmpty()) {
+                return url.getProtocol() + "://" + url.getHost() + path;
+            }
+            List<String> essentialParams = List.of("article_id", "id", "no", "idx", "idxno", "pno", "newsid", "materialId");
+            String preservedQuery = Arrays.stream(query.split("&"))
+                .filter(param -> essentialParams.stream().anyMatch(key -> param.startsWith(key + "=")))
+                .sorted()
+                .collect(Collectors.joining("&"));
+            String baseUrl = url.getProtocol() + "://" + url.getHost() + path;
+            return preservedQuery.isEmpty() ? baseUrl : baseUrl + "?" + preservedQuery;
+        } catch (MalformedURLException e) {
+            return urlString;
+        }
+    }
+}

--- a/src/main/java/com/example/nocap/domain/analysis/service/parser/SeDailyParser.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/parser/SeDailyParser.java
@@ -1,0 +1,123 @@
+package com.example.nocap.domain.analysis.service.parser;
+
+import com.example.nocap.domain.mainnews.entity.MainNews;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Component
+@Order(2) // ChosunBizParser 다음에 실행되도록 우선순위 설정
+@Slf4j
+public class SeDailyParser implements SiteSpecificParser {
+
+    @Override
+    public boolean canParse(String url) {
+        return url.contains("sedaily.com");
+    }
+
+    @Override
+    public MainNews extract(Document doc, String url) {
+        log.info(">>>>> Executing SeDailyParser for: {}", url);
+
+        // 1. 정보 추출
+        String title = extractTitle(doc);
+        String image = getMetaTagContent(doc, "og:image");
+        String dateString = extractPublishedDate(doc);
+        String plainContent = extractContent(doc);
+
+        log.info(">>>>> JSON Title: {}", title);
+        log.info(">>>>> JSON Date: {}", dateString);
+
+        if (plainContent == null || plainContent.isBlank()) {
+            log.warn("SeDailyParser: 본문 내용을 추출하지 못했습니다. URL: {}", url);
+            return null;
+        }
+
+        log.info(">>>>> JSON Content: {}", plainContent);
+
+        // 2. MainNews 객체 생성 및 반환
+        return MainNews.builder()
+            .url(url)
+            .canonicalUrl(getMetaTagContent(doc, "og:url"))
+            .title(unescape(title))
+            .content(plainContent)
+            .image(image)
+            .date(parseDateString(dateString))
+            .build();
+    }
+
+
+    private String extractTitle(Document doc) {
+        Element titleElement = doc.selectFirst("h1.art_tit");
+        if (titleElement != null) {
+            return titleElement.text();
+        }
+        return getMetaTagContent(doc, "og:title"); // Fallback
+    }
+
+    private String extractContent(Document doc) {
+        Element contentElement = doc.selectFirst("div.article_view[itemprop=articleBody]");
+        if (contentElement != null) {
+            // 본문 내부의 불필요한 광고, 저작권, 기자 정보 등 제거
+            contentElement.select("figure, figcaption, .art_rel, .sub_ad_banner, .article_copy, .reporter_wrap").remove();
+
+            // HTML을 문자열로 가져온 뒤, Jsoup.parse().text()로 태그를 확실하게 제거
+            String contentHtml = contentElement.html();
+            return Jsoup.parse(contentHtml).text();
+        }
+        return null;
+    }
+
+    private String extractPublishedDate(Document doc) {
+        // "입력" 텍스트를 포함하는 첫 번째 span.url_txt 요소 찾기
+        Element dateElement = doc.select("span.url_txt:contains(입력)").first();
+        if (dateElement != null) {
+            // "입력" 단어 제거 후 날짜 부분만 추출
+            return dateElement.text().replace("입력", "").trim();
+        }
+        return getMetaTagContent(doc, "article:published_time"); // Fallback
+    }
+
+    private String getMetaTagContent(Document doc, String property) {
+        Element metaTag = doc.selectFirst("meta[property=" + property + "]");
+        return (metaTag != null) ? metaTag.attr("content") : "";
+    }
+
+    private String unescape(String text) {
+        if (text == null) return null;
+        return text.replace("\\\"", "\"").replace("\\'", "'");
+    }
+
+    private String parseDateString(String dateString) {
+        if (dateString == null || dateString.isBlank()) return null;
+
+        // "yyyy-MM-dd HH:mm:ss" 형식에 맞는 포맷터
+        DateTimeFormatter customFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        try {
+            return LocalDateTime.parse(dateString, customFormatter).format(outputFormatter);
+        } catch (Exception e) {
+            log.warn("SeDailyParser: 날짜 파싱 실패 ({}): {}", customFormatter, dateString);
+        }
+
+        // 다른 범용 포맷들도 시도
+        List<DateTimeFormatter> formatters = List.of(
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME, DateTimeFormatter.RFC_1123_DATE_TIME
+        );
+        for (DateTimeFormatter formatter : formatters) {
+            try {
+                return ZonedDateTime.parse(dateString, formatter).format(outputFormatter);
+            } catch (Exception ex) { /* 다음 시도 */ }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/nocap/domain/analysis/service/parser/SiteSpecificParser.java
+++ b/src/main/java/com/example/nocap/domain/analysis/service/parser/SiteSpecificParser.java
@@ -1,0 +1,13 @@
+package com.example.nocap.domain.analysis.service.parser;
+
+import com.example.nocap.domain.mainnews.entity.MainNews;
+import org.jsoup.nodes.Document;
+
+public interface SiteSpecificParser {
+
+    // 이 파서가 해당 URL을 처리할 수 있는지 여부를 반환
+    boolean canParse(String url);
+
+    // ✨ Document와 url을 모두 받아서 MainNews를 반환하도록 수정
+    MainNews extract(Document doc, String url);
+}

--- a/src/main/java/com/example/nocap/domain/searchnews/dto/NewsSearchResponseDto.java
+++ b/src/main/java/com/example/nocap/domain/searchnews/dto/NewsSearchResponseDto.java
@@ -13,6 +13,7 @@ public class NewsSearchResponseDto {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Item {
         private String title;
+        private String link;
         private String originallink;
         private String pubDate;
     }

--- a/src/main/java/com/example/nocap/domain/searchnews/service/SearchNewsService.java
+++ b/src/main/java/com/example/nocap/domain/searchnews/service/SearchNewsService.java
@@ -8,51 +8,70 @@ import com.example.nocap.exception.CustomException;
 import com.example.nocap.exception.ErrorCode;
 import com.example.nocap.global.NaverApiConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import net.dankito.readability4j.Article;
-import net.dankito.readability4j.Readability4J;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SearchNewsService {
 
-    private static final String SECTION_URL_TEMPLATE = "https://news.naver.com/section/%d";
     private final NaverApiConfig naverApiConfig;
-    private final ArticleExtractionService articleExtractionService;
     private final ObjectMapper objectMapper;
+    private final ArticleExtractionService articleExtractionService;
 
-    private static final Logger log = LoggerFactory.getLogger(SearchNewsService.class);
+    public List<SearchNewsDto> getNewsBySearch(String search) {
+        if (isUrl(search)) {
+            return getNewsByUrl(search);
+        } else {
+            return getNewsByKeyword(search);
+        }
+    }
 
-    // 카테고리별 뉴스 검색
+    public List<SearchNewsDto> getNewsByUrl(String url) {
+        MainNews mainNews = articleExtractionService.extract(url);
+
+        if (mainNews == null) {
+            throw new CustomException(ErrorCode.NEWS_EXTRACTING_ERROR);
+        }
+
+        SearchNewsDto newsDto = SearchNewsDto.builder()
+            .url(mainNews.getCanonicalUrl())
+            .title(mainNews.getTitle())
+            .content(mainNews.getContent())
+            .date(mainNews.getDate())
+            .image(mainNews.getImage())
+            .build();
+        return List.of(newsDto);
+    }
+
     public List<SearchNewsDto> getNewsByCategory(int category) {
-        String sectionUrl = String.format(SECTION_URL_TEMPLATE, category);
+        String sectionUrl = String.format("https://news.naver.com/section/%d", category);
         try {
             Document sectionDoc = Jsoup.connect(sectionUrl).userAgent("Mozilla/5.0").get();
             List<String> naverUrls = sectionDoc.select("a[href^=\"https://n.news.naver.com/mnews/article\"]")
@@ -60,14 +79,13 @@ public class SearchNewsService {
                 .map(a -> a.absUrl("href"))
                 .distinct()
                 .filter(u -> !u.contains("/article/comment/"))
-                .limit(10)
+                .limit(20)
                 .toList();
 
             return naverUrls.parallelStream()
                 .map(naverUrl -> {
                     try {
-                        Document doc = Jsoup.connect(naverUrl).userAgent("Mozilla/5.0").get();
-                        return parse(doc);
+                        return parseNaverNews(naverUrl);
                     } catch (Exception e) {
                         log.error("카테고리 기사 크롤링 실패: {} - 오류: {}", naverUrl, e.getMessage());
                         return null;
@@ -81,42 +99,75 @@ public class SearchNewsService {
         }
     }
 
-    /**
-     * Document 객체를 받아 뉴스 정보를 추출하는 메소드
-     */
-    public SearchNewsDto parse(Document doc) {
+    public List<SearchNewsDto> getNewsByKeyword(String keyword) {
+        log.info("키워드 '{}'로 뉴스 검색을 시작합니다.", keyword);
+        String jsonString = requestRawJson(keyword);
+        NewsSearchResponseDto responseDto = jsonToDto(jsonString);
+        sanitizeItems(responseDto);
 
-        // 1. 원본 기사 URL 추출
+        return responseDto.getItems().parallelStream()
+            .map(item -> {
+                log.info("Processing Item -> Naver Link: [{}], Original Link: [{}]", item.getLink(), item.getOriginallink());
+
+                String naverUrl = item.getLink();
+                String originalUrl = item.getOriginallink();
+                try {
+                    SearchNewsDto parsedDto = parseNaverNews(naverUrl);
+                    if (parsedDto != null) {
+                        parsedDto.setUrl(originalUrl);
+                        parsedDto.setTitle(item.getTitle());
+                        parsedDto.setDate(parseDateString(item.getPubDate()));
+                    }
+                    return parsedDto;
+                } catch (Exception e) {
+                    log.error("키워드 기사 크롤링 실패: {} - 오류: {}", naverUrl, e.getMessage());
+                    return null;
+                }
+            })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    }
+
+    private SearchNewsDto parseNaverNews(String url) throws IOException {
+        Document doc = Jsoup.connect(url).userAgent("Mozilla/5.0").get();
         Element originalLinkElement = doc.selectFirst("a.media_end_head_origin_link");
-        String finalUrl = (originalLinkElement != null) ? originalLinkElement.attr("href") : doc.location();
-
-        // 2. 제목, 이미지, 날짜 추출
+        String finalUrl = (originalLinkElement != null) ? originalLinkElement.attr("href") : url;
         String title = getMetaTagContent(doc, "og:title");
         String image = getMetaTagContent(doc, "og:image");
         String date = extractPublishedDate(doc);
+        String htmlContent = extractNaverNewsContent(doc);
 
-        // ✨ 3. 본문을 HTML 태그 포함하여 추출
-        Element bodyEl = doc.selectFirst("#dic_area");
-        if (bodyEl == null) {
-            throw new IllegalStateException("본문 요소를 찾을 수 없습니다: " + doc.location());
-        }
-
-        // ✨ 4. 본문 내부의 불필요한 요소(이미지 테이블, 기자 정보 등) 제거
-        bodyEl.select("table, .byline").remove();
-        String htmlContent = bodyEl.html()
-            .replaceAll("(<br>\\s*){3,}", "<br><br>") // 연속된 <br> 정리
-            .trim();
+        if (htmlContent == null || htmlContent.isBlank()) return null;
 
         return SearchNewsDto.builder()
             .url(finalUrl)
             .title(unescape(title))
             .date(parseDateString(date))
-            .content(htmlContent) // HTML 태그가 포함된 본문
+            .content(htmlContent)
             .image(image)
             .build();
     }
 
-    // --- 헬퍼 메소드들 ---
+    private String extractNaverNewsContent(Document doc) {
+        String[] contentSelectors = {
+            "._article_content", // 1순위: 스포츠, 연예 뉴스
+            "#dic_area",         // 2순위: 일반 텍스트 뉴스
+            "#articeBody",       // 3순위: 구버전 연예/스포츠 뉴스
+            ".go_trans"          // 4순위: TV 뉴스
+        };
+        Element contentArea = null;
+        for (String selector : contentSelectors) {
+            contentArea = doc.selectFirst(selector);
+            if (contentArea != null) break;
+        }
+        if (contentArea == null) {
+            log.warn("네이버 뉴스 본문 영역을 찾을 수 없음: {}", doc.location());
+            return null;
+        }
+        contentArea.select("script, style, table, .end_photo_org, .img_desc, .vod_player, .ad, .byline, .copyright, [class*='social']").remove();
+
+        return contentArea.text();
+    }
 
     private String getMetaTagContent(Document doc, String property) {
         Element metaTag = doc.selectFirst("meta[property=" + property + "]");
@@ -142,11 +193,15 @@ public class SearchNewsService {
     }
 
     private String parseDateString(String dateString) {
-        if (dateString == null || dateString.isBlank()) return null;
+        if (dateString == null || dateString.isBlank()) {
+            return null;
+        }
         DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         List<DateTimeFormatter> formatters = List.of(
-            DateTimeFormatter.RFC_1123_DATE_TIME, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
-            DateTimeFormatter.ofPattern("yyyy. M. d. HH:mm"), DateTimeFormatter.ofPattern("yyyy.MM.dd. a H:mm"),
+            DateTimeFormatter.RFC_1123_DATE_TIME,
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+            DateTimeFormatter.ofPattern("yyyy. M. d. HH:mm"),
+            DateTimeFormatter.ofPattern("yyyy.MM.dd. a H:mm"),
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
         );
         for (DateTimeFormatter formatter : formatters) {
@@ -166,42 +221,15 @@ public class SearchNewsService {
         return null;
     }
 
-    public List<SearchNewsDto> getNewsByKeyword(String keyword) {
-        log.info("키워드 '{}'로 뉴스 검색을 시작합니다.", keyword);
-        String jsonString = requestRawJson(keyword);
-        NewsSearchResponseDto responseDto = jsonToDto(jsonString);
-        sanitizeItems(responseDto);
-
-        return responseDto.getItems().parallelStream()
-            .map(item -> {
-                String originalUrl = item.getOriginallink();
-                if (originalUrl == null || originalUrl.isEmpty()) {
-                    return null;
-                }
-                try {
-                    var extracted = articleExtractionService.extract(originalUrl);
-                    return SearchNewsDto.builder()
-                        .url(originalUrl)
-                        .title(item.getTitle())
-                        .date(parseDateString(item.getPubDate())) // 날짜 변환
-                        .content(extracted.getContent())
-                        .image(extracted.getImage())
-                        .build();
-                } catch (Exception e) {
-                    log.error("개별 기사 크롤링 실패: {} - 오류: {}", originalUrl, e.getMessage());
-                    return null;
-                }
-            })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
-    }
-
     private String requestRawJson(String rawKeyword) {
         String query;
-        query = URLEncoder.encode(rawKeyword, StandardCharsets.UTF_8);
+        try {
+            query = URLEncoder.encode(rawKeyword, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("검색어 인코딩 실패", e);
+        }
 
         String apiURL = "https://openapi.naver.com/v1/search/news.json?query=" + query + "&display=20&sort=sim";
-
         Map<String, String> headers = new HashMap<>();
         headers.put("X-Naver-Client-Id", naverApiConfig.getClientId());
         headers.put("X-Naver-Client-Secret", naverApiConfig.getClientSecret());
@@ -212,9 +240,7 @@ public class SearchNewsService {
             headers.forEach(con::setRequestProperty);
 
             int code = con.getResponseCode();
-            InputStream is = (code == HttpURLConnection.HTTP_OK)
-                ? con.getInputStream()
-                : con.getErrorStream();
+            InputStream is = (code == HttpURLConnection.HTTP_OK) ? con.getInputStream() : con.getErrorStream();
             return readBody(is);
         } catch (IOException e) {
             throw new RuntimeException("API 요청 실패", e);
@@ -262,181 +288,18 @@ public class SearchNewsService {
         }
     }
 
+    private static final Pattern IP_ADDRESS_PATTERN = Pattern.compile("^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})$");
 
-    // URL로 뉴스 검색
-    public List<SearchNewsDto> getNewsByUrl(String url) {
-        return List.of(extract(url));
-    }
-
-    public SearchNewsDto extract(String url) {
-        try {
-            Document doc = Jsoup.connect(url).get();
-            if (!isArticleByConfidenceScore(doc)) {
-                throw new CustomException(ErrorCode.NOT_A_NEWS_ARTICLE);
-            }
-
-            preprocessDocument(doc);
-
-            String ogTitle = getMetaTagContent(doc, "og:title");
-            String ogImage = getMetaTagContent(doc, "og:image");
-
-            Article article = new Readability4J(url, doc.html()).parse();
-            String htmlContent = article.getContent();
-
-            String finalTitle = (!ogTitle.isEmpty()) ? ogTitle : article.getTitle();
-            finalTitle = unescape(finalTitle);
-
-            String pubDateString = extractPublishedDate(doc);
-            String pubDate = parseDateString(pubDateString); // String -> LocalDateTime 변환
-
-            if (htmlContent == null || htmlContent.trim().isEmpty()) {
-                throw new CustomException(ErrorCode.NEWS_EXTRACTING_ERROR);
-            }
-            return SearchNewsDto.builder()
-                .url(url)
-                .title(finalTitle)
-                .content(htmlContent)
-                .image(ogImage)
-                .date(pubDate)
-                .build();
-
-        } catch (IOException e) {
-            throw new CustomException(ErrorCode.NEWS_EXTRACTING_ERROR);
-        }
-    }
-
-    private void preprocessDocument(Document doc) {
-        doc.select(".read_cont, em.img_desc, span.img_desc, .desc_thumb").remove();
-    }
-
-    private String unescape(String text) {
-        if (text == null) return null;
-        return text.replace("\\\"", "\"").replace("\\'", "'");
-    }
-
-    private String getMetaTagContent(Document doc, String property) {
-        Element metaTag = doc.selectFirst("meta[property=" + property + "]");
-        return (metaTag != null) ? metaTag.attr("content") : "";
-    }
-
-    private String extractPublishedDate(Document doc) {
-        // 우선순위대로 날짜를 포함할 가능성이 높은 선택자 목록
-        String[] dateSelectors = {
-            "meta[property=article:published_time]", // 1순위: 국제 표준 메타 태그
-            "span.num_date",
-            "span._ARTICLE_DATE_TIME",              // 2순위: 네이버 뉴스
-            "span.t11",                             // 3순위: 네이버 뉴스 (구버전)
-            "span[class*='date']",                  // 4순위: 'date' 클래스를 포함하는 span
-            "time"                                  // 5순위: <time> 태그
-        };
-
-        for (String selector : dateSelectors) {
-            Element dateElement = doc.selectFirst(selector);
-            if (dateElement != null) {
-                if (dateElement.hasAttr("content")) return dateElement.attr("content");
-                if (dateElement.hasAttr("data-date-time")) return dateElement.attr("data-date-time");
-                return dateElement.text();
-            }
-        }
-        return null; // 날짜를 찾지 못한 경우
-    }
-
-    private String parseDateString(String dateString) {
-        if (dateString == null || dateString.isBlank()) {
-            return null;
-        }
-
-        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd"); // 최종 출력 형식
-
-        List<DateTimeFormatter> formatters = List.of(
-            DateTimeFormatter.ISO_OFFSET_DATE_TIME,
-            DateTimeFormatter.RFC_1123_DATE_TIME,
-            DateTimeFormatter.ofPattern("yyyy. M. d. HH:mm"),
-            DateTimeFormatter.ofPattern("yyyy.MM.dd. a H:mm"),
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-        );
-
-        for (DateTimeFormatter formatter : formatters) {
-            try {
-                // 시간대 정보가 포함된 형식(RFC, ISO)은 ZonedDateTime으로 파싱
-                return ZonedDateTime.parse(dateString, formatter).format(outputFormatter);
-            } catch (java.time.format.DateTimeParseException e1) {
-                try {
-                    // 시간대 정보가 없는 형식은 LocalDateTime으로 파싱
-                    return LocalDateTime.parse(dateString, formatter).format(outputFormatter);
-                } catch (java.time.format.DateTimeParseException e2) {
-                    // 둘 다 실패하면 다음 포맷터로 계속
-                }
-            }
-        }
-
-        // 정규식으로 'YYYY-MM-DD' 또는 'YYYY.MM.DD' 형태만 추출 시도
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("\\d{4}[-.]\\d{2}[-.]\\d{2}");
-        java.util.regex.Matcher matcher = pattern.matcher(dateString);
-        if (matcher.find()) {
-            return matcher.group(0).replace(".", "-");
-        }
-
-        return null; // 모든 형식에 실패하면 null 반환
-    }
-
-    private boolean isArticleByConfidenceScore(Document doc) {
-        int confidenceScore = 0;
-        final int THRESHOLD = 4;
-
-        Element ogTypeElement = doc.selectFirst("meta[property=og:type]");
-        if (ogTypeElement != null && "article".equalsIgnoreCase(ogTypeElement.attr("content"))) {
-            confidenceScore += 5;
-        }
-        if (doc.selectFirst("article") != null) {
-            confidenceScore += 3;
-        }
-        if (doc.selectFirst("div[class*='article'], div[class*='content'], div[id*='article'], div[id*='content']") != null) {
-            confidenceScore += 2;
-        }
-        if (doc.selectFirst("h1") != null) {
-            confidenceScore += 1;
-        }
-
-        return confidenceScore >= THRESHOLD;
-    }
-
-    public List<SearchNewsDto> getNewsBySearch(String search) {
-        if (isUrl(search)) {
-            return getNewsByUrl(search);
-        } else {
-            return getNewsByKeyword(search);
-        }
-    }
-
-    private static final Pattern IP_ADDRESS_PATTERN =
-        Pattern.compile("^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})$");
-
-    public static boolean isUrl(String input) {
+    private boolean isUrl(String input) {
         if (input == null || input.trim().isEmpty()) {
             throw new CustomException(ErrorCode.EMPTY_INPUT);
         }
-
         String trimmedInput = input.trim();
-
-        // 1. 형식 검사: URL의 명확한 특징이 있는가?
-        if (trimmedInput.matches("^[a-zA-Z]+://.*")) {
-            return true;
-        }
-        if (trimmedInput.toLowerCase().startsWith("www.")) {
-            return true;
-        }
-        if (trimmedInput.toLowerCase().startsWith("localhost")) {
-            return true;
-        }
-        if (IP_ADDRESS_PATTERN.matcher(trimmedInput).matches()) {
-            return true;
-        }
-        if (trimmedInput.contains(".") && !trimmedInput.contains(" ")) {
-            return true;
-        }
-
-        // 2. 위의 모든 URL 조건에 해당하지 않으면 검색어 (false)
+        if (trimmedInput.matches("^[a-zA-Z]+://.*")) return true;
+        if (trimmedInput.toLowerCase().startsWith("www.")) return true;
+        if (trimmedInput.toLowerCase().startsWith("localhost")) return true;
+        if (IP_ADDRESS_PATTERN.matcher(trimmedInput).matches()) return true;
+        if (trimmedInput.contains(".") && !trimmedInput.contains(" ")) return true;
         return false;
     }
 }


### PR DESCRIPTION
### 반영 브랜치
refactor/news-content -> develop

### 변경사항
- 관련뉴스 본문에서 HTML 태그 제거
- 카테고리별 뉴스에서 HTML 태그 제거
- ArticleExtractionService에서는 Jsoup 호출 후 Parser호출
- 이후 작업에 대해 주요 뉴스사별 전문 Parser와 범용 Parser로 나눠서 추출

### 테스트 결과
<img width="2022" height="884" alt="image" src="https://github.com/user-attachments/assets/366a546b-926d-47c4-8d63-0b9edea300ab" />
<img width="2721" height="770" alt="image" src="https://github.com/user-attachments/assets/99f17a74-b48f-4487-902e-f33417577720" />